### PR TITLE
Merge german particles into main verbs

### DIFF
--- a/apps/db_management/src/data/germanverbs.yaml
+++ b/apps/db_management/src/data/germanverbs.yaml
@@ -2070,3 +2070,11 @@ bedürfen:
       du: bedarfst
       es: bedarf
 
+blenden:
+  language: de
+  infinitive: blenden
+  translations:
+    en: blind
+  variations:
+    - definition: fade
+      pariticle: ab

--- a/apps/db_management/src/models/german/createStandardConjugation.ts
+++ b/apps/db_management/src/models/german/createStandardConjugation.ts
@@ -8,9 +8,10 @@ export const createStandardConjugation = (
   particle = '',
 ): BaseGermanVerb => {
   const defaultEnding = kranton(stem) ? 'e' : '';
+  console.log('!!!!!', infinitive, defaultEnding);
 
   return {
-    partizip: `ge${stem}t`,
+    partizip: `ge${stem}${defaultEnding}t`,
     [GermanTenses.präsens]: {
       [GermanPronounKeys.ich]: `${particle}${stem}e`,
       [GermanPronounKeys.du]: `${particle}${stem}${defaultEnding}st`,
@@ -26,18 +27,18 @@ export const createStandardConjugation = (
       [GermanPronounKeys.ihr]: `${particle}${stem}et`,
     },
     [GermanTenses.präteritum]: {
-      [GermanPronounKeys.ich]: `${particle}${stem}te`,
-      [GermanPronounKeys.du]: `${particle}${stem}test`,
-      [GermanPronounKeys.es]: `${particle}${stem}te`,
-      [GermanPronounKeys.wir]: `${particle}${stem}ten`,
-      [GermanPronounKeys.ihr]: `${particle}${stem}tet`,
+      [GermanPronounKeys.ich]: `${particle}${stem}${defaultEnding}te`,
+      [GermanPronounKeys.du]: `${particle}${stem}${defaultEnding}test`,
+      [GermanPronounKeys.es]: `${particle}${stem}${defaultEnding}te`,
+      [GermanPronounKeys.wir]: `${particle}${stem}${defaultEnding}ten`,
+      [GermanPronounKeys.ihr]: `${particle}${stem}${defaultEnding}tet`,
     },
     [GermanTenses.k2präsens]: {
-      [GermanPronounKeys.ich]: `${particle}${stem}te`,
-      [GermanPronounKeys.du]: `${particle}${stem}test`,
-      [GermanPronounKeys.es]: `${particle}${stem}te`,
-      [GermanPronounKeys.wir]: `${particle}${stem}ten`,
-      [GermanPronounKeys.ihr]: `${particle}${stem}tet`,
+      [GermanPronounKeys.ich]: `${particle}${stem}${defaultEnding}te`,
+      [GermanPronounKeys.du]: `${particle}${stem}${defaultEnding}test`,
+      [GermanPronounKeys.es]: `${particle}${stem}${defaultEnding}te`,
+      [GermanPronounKeys.wir]: `${particle}${stem}${defaultEnding}ten`,
+      [GermanPronounKeys.ihr]: `${particle}${stem}${defaultEnding}tet`,
     },
   } as BaseGermanVerb;
 };

--- a/apps/db_management/src/models/german/createStandardConjugation.ts
+++ b/apps/db_management/src/models/german/createStandardConjugation.ts
@@ -8,7 +8,6 @@ export const createStandardConjugation = (
   particle = '',
 ): BaseGermanVerb => {
   const defaultEnding = kranton(stem) ? 'e' : '';
-  console.log('!!!!!', infinitive, defaultEnding);
 
   return {
     partizip: `ge${stem}${defaultEnding}t`,

--- a/apps/db_management/src/models/german/processDeRecord.ts
+++ b/apps/db_management/src/models/german/processDeRecord.ts
@@ -1,6 +1,10 @@
 import { LanguageVerbBase } from 'global-types';
 import { cloneDeep } from 'lodash';
-import { isGermanVerb, GermanVerbVariation } from 'german-types';
+import {
+  isGermanVerb,
+  GermanVerbVariation,
+  separableArray,
+} from 'german-types';
 import { generateStems } from '@germanUtilities/generateStems';
 import { processVariation } from './processVariation';
 import { createStandardConjugation } from './createStandardConjugation';
@@ -9,6 +13,13 @@ export type BaseGermanVerb = Omit<
   GermanVerbVariation,
   'translations' | 'hilfsverb' | 'infinitive' | 'stems'
 >;
+
+const particleIsInseperable = (particle?: string) => {
+  if (particle && !separableArray.includes(particle)) {
+    return particle;
+  }
+  return;
+};
 
 export const processDeRecord = (record: LanguageVerbBase) => {
   if (!isGermanVerb(record)) {
@@ -29,6 +40,7 @@ export const processDeRecord = (record: LanguageVerbBase) => {
     hilfsverb,
     language,
     partizip,
+    particle,
     stems,
     translations,
     weakEndings,
@@ -47,12 +59,14 @@ export const processDeRecord = (record: LanguageVerbBase) => {
     weakEndings,
   };
 
-  const [infinitiveStem, particle] = generateStems(infinitive);
+  const [infinitiveStem, _particle] = generateStems(infinitive);
+
+  const verbParticle = particleIsInseperable(particle) || _particle;
 
   const baseHydratedVerb = {
     hilfsverb,
     translations,
-    ...createStandardConjugation(infinitive, infinitiveStem, particle),
+    ...createStandardConjugation(infinitive, infinitiveStem, verbParticle),
   };
 
   let { variations: variationsSource = [] } = record;

--- a/apps/db_management/src/models/german/processDeRecordVerbs.spec.ts
+++ b/apps/db_management/src/models/german/processDeRecordVerbs.spec.ts
@@ -3,6 +3,8 @@ import { processDeRecord } from './processDeRecord';
 import {
   bleibenGermanVerb,
   bleibenReturnObject,
+  blendenGermanVerb,
+  blendenReturnObject,
   fliegenGermanVerb,
   fliegenReturnObject,
   gehenGermanVerb,
@@ -21,6 +23,8 @@ import {
 import {
   bedürfenGermanVerb,
   bedürfenReturnObject,
+  brennenGermanVerb,
+  brennenReturnObject,
   gelingenGermanVerb,
   gelingenReturnObject,
   widersprechenGermanVerb,
@@ -29,65 +33,11 @@ import {
   ähnelnReturnObject,
 } from './spec_constants/newVerbsSpec';
 
+// TODO: next pass loop through dictionary
 describe('processDeRecord matches real conjugations:', () => {
   it('returns brennen correctly', () => {
-    const brennen = {
-      infinitive: 'brennen',
-      language: LanguageMap.de,
-      translations: {
-        en: ['burn', 'shine', 'distil'],
-      },
-      weakEndings: true,
-      stems: {
-        präteritum: 'a',
-        k2präsens: 'e',
-        partizip: 'a',
-      },
-    };
-
-    const brennen_expected = {
-      infinitive: 'brennen',
-      language: LanguageMap.de,
-      variations: [
-        {
-          hilfsverb: 'haben',
-          k2präsens: {
-            '1033': 'brennte',
-            '1041': 'brennten',
-            '1098': 'brenntest',
-            '1106': 'brenntet',
-            '1548': 'brennte',
-          },
-          konjunktiv: {
-            '1033': 'brenne',
-            '1041': 'brennen',
-            '1098': 'brennest',
-            '1106': 'brennet',
-            '1548': 'brenne',
-          },
-          partizip: 'gebrannt',
-          präsens: {
-            '1033': 'brenne',
-            '1041': 'brennen',
-            '1098': 'brennst',
-            '1106': 'brennt',
-            '1548': 'brennt',
-          },
-          präteritum: {
-            '1033': 'brannte',
-            '1041': 'brannten',
-            '1098': 'branntest',
-            '1106': 'branntet',
-            '1548': 'brannte',
-          },
-          translations: {
-            en: ['burn', 'shine', 'distil'],
-          },
-        },
-      ],
-    };
-    const result = processDeRecord(brennen);
-    expect(result).toEqual(brennen_expected);
+    const result = processDeRecord(brennenGermanVerb);
+    expect(result).toEqual(brennenReturnObject);
   });
 
   it('returns haben correctly', () => {
@@ -148,5 +98,10 @@ describe('processDeRecord matches real conjugations:', () => {
   it('returns nehmen correctly', () => {
     const result = processDeRecord(nehmenGermanVerb);
     expect(result).toEqual(nehmenReturnObject);
+  });
+
+  it.skip('returns blenden correctly', () => {
+    const result = processDeRecord(blendenGermanVerb);
+    expect(result).toEqual(blendenReturnObject);
   });
 });

--- a/apps/db_management/src/models/german/processDeRecordVerbs.spec.ts
+++ b/apps/db_management/src/models/german/processDeRecordVerbs.spec.ts
@@ -1,4 +1,4 @@
-import { LanguageMap } from 'global-types';
+import { LanguageMap, LanguageVerbCandidate } from 'global-types';
 import { processDeRecord } from './processDeRecord';
 import {
   bleibenGermanVerb,
@@ -33,75 +33,29 @@ import {
   ähnelnReturnObject,
 } from './spec_constants/newVerbsSpec';
 
-// TODO: next pass loop through dictionary
+const verbsToTest = [
+  ['brennen', brennenGermanVerb, brennenReturnObject],
+  ['haben', habenGermanVerb, habenReturnObject],
+  ['sein', seinGermanVerb, seinReturnObject],
+  ['werden', werdenGermanVerb, werdenReturnObject],
+  ['können', könnenGermanVerb, könnenReturnObject],
+  ['gehen', gehenGermanVerb, gehenReturnObject],
+  ['fliegen', fliegenGermanVerb, fliegenReturnObject],
+  ['bleiben', bleibenGermanVerb, bleibenReturnObject],
+  ['ähneln', ähnelnGermanVerb, ähnelnReturnObject],
+  ['bedürfen', bedürfenGermanVerb, bedürfenReturnObject],
+  ['widersprechen', widersprechenGermanVerb, widersprechenReturnObject],
+  ['gelingen', gelingenGermanVerb, gelingenReturnObject],
+  ['nehmen', nehmenGermanVerb, nehmenReturnObject],
+  ['blenden', blendenGermanVerb, blendenReturnObject],
+];
+
 describe('processDeRecord matches real conjugations:', () => {
-  it('returns brennen correctly', () => {
-    const result = processDeRecord(brennenGermanVerb);
-    expect(result).toEqual(brennenReturnObject);
-  });
-
-  it('returns haben correctly', () => {
-    const result = processDeRecord(habenGermanVerb);
-    expect(result).toEqual(habenReturnObject);
-  });
-
-  it('returns sein correctly', () => {
-    const result = processDeRecord(seinGermanVerb);
-    expect(result).toEqual(seinReturnObject);
-  });
-
-  it('returns werden correctly', () => {
-    const result = processDeRecord(werdenGermanVerb);
-    expect(result).toEqual(werdenReturnObject);
-  });
-
-  it('returns können correctly', () => {
-    const result = processDeRecord(könnenGermanVerb);
-    expect(result).toEqual(könnenReturnObject);
-  });
-
-  it('returns gehen correctly', () => {
-    const result = processDeRecord(gehenGermanVerb);
-    expect(result).toEqual(gehenReturnObject);
-  });
-
-  it('returns fliegen correctly', () => {
-    const result = processDeRecord(fliegenGermanVerb);
-    expect(result).toEqual(fliegenReturnObject);
-  });
-
-  it('returns bleiben correctly', () => {
-    const result = processDeRecord(bleibenGermanVerb);
-    expect(result).toEqual(bleibenReturnObject);
-  });
-
-  it('returns ähneln correctly', () => {
-    const result = processDeRecord(ähnelnGermanVerb);
-    expect(result).toEqual(ähnelnReturnObject);
-  });
-
-  it('returns bedürfen correctly', () => {
-    const result = processDeRecord(bedürfenGermanVerb);
-    expect(result).toEqual(bedürfenReturnObject);
-  });
-
-  it('returns widersprechen correctly', () => {
-    const result = processDeRecord(widersprechenGermanVerb);
-    expect(result).toEqual(widersprechenReturnObject);
-  });
-
-  it('returns gelingen correctly', () => {
-    const result = processDeRecord(gelingenGermanVerb);
-    expect(result).toEqual(gelingenReturnObject);
-  });
-
-  it('returns nehmen correctly', () => {
-    const result = processDeRecord(nehmenGermanVerb);
-    expect(result).toEqual(nehmenReturnObject);
-  });
-
-  it('returns blenden correctly', () => {
-    const result = processDeRecord(blendenGermanVerb);
-    expect(result).toEqual(blendenReturnObject);
-  });
+  test.each(verbsToTest)(
+    `'returns %s correctly'`,
+    (infinitive, input, output) => {
+      const result = processDeRecord(input as LanguageVerbCandidate);
+      expect(result).toEqual(output);
+    },
+  );
 });

--- a/apps/db_management/src/models/german/processDeRecordVerbs.spec.ts
+++ b/apps/db_management/src/models/german/processDeRecordVerbs.spec.ts
@@ -100,7 +100,7 @@ describe('processDeRecord matches real conjugations:', () => {
     expect(result).toEqual(nehmenReturnObject);
   });
 
-  it.skip('returns blenden correctly', () => {
+  it('returns blenden correctly', () => {
     const result = processDeRecord(blendenGermanVerb);
     expect(result).toEqual(blendenReturnObject);
   });

--- a/apps/db_management/src/models/german/processVariation.ts
+++ b/apps/db_management/src/models/german/processVariation.ts
@@ -19,9 +19,10 @@ export const processVariation = (
   record: any,
   infinitive: string,
 ) => {
-  const { dative, genitive, impersonal, translations, weakEndings } = record;
+  const { dative, genitive, impersonal, particle, translations, weakEndings } =
+    record;
 
-  const [infinitiveStem, particle] = generateStems(infinitive);
+  const [infinitiveStem, stemParticle] = generateStems(infinitive);
 
   const hilfsverb: string =
     'hilfsverb' in record && typeof record.hilfsverb === 'string'
@@ -39,10 +40,6 @@ export const processVariation = (
 
   if ('partizip' in record && record.partizip) {
     hydratedVerb.partizip = record.partizip;
-  }
-
-  if (particle in record) {
-    console.log('HURRAY');
   }
 
   if (verbIsIrregular(record, [...GERMAN_IRREGULAR_KEYS])) {
@@ -92,7 +89,7 @@ export const processVariation = (
           infinitiveStem,
           stems.präteritum,
           weakEndings || false,
-          particle,
+          stemParticle,
         );
       }
 
@@ -100,7 +97,7 @@ export const processVariation = (
         hydratedVerb.konjunktiv = konjunktivConjugation(
           infinitiveStem,
           stems.konjunktiv,
-          particle,
+          stemParticle,
         );
       }
 
@@ -109,7 +106,7 @@ export const processVariation = (
           infinitiveStem,
           stems.k2präsens || stems.präteritum || '',
           weakEndings || false,
-          particle,
+          stemParticle,
         );
       }
     }
@@ -154,6 +151,10 @@ export const processVariation = (
         delete tenseGroup[GermanPronounKeys.ihr];
       }
     });
+  }
+
+  if (particle) {
+    hydratedVerb.partizip = `${particle}${hydratedVerb.partizip}`;
   }
 
   return hydratedVerb;

--- a/apps/db_management/src/models/german/processVariation.ts
+++ b/apps/db_management/src/models/german/processVariation.ts
@@ -2,10 +2,7 @@ import {
   GERMAN_IRREGULAR_KEYS,
   GermanPronounKeys,
   GermanTenses,
-  GermanVerbHydrated,
-  isGermanVerb,
   GermanPronounCode,
-  GermanVerbVariation,
 } from 'german-types';
 import { BaseGermanVerb } from './processDeRecord';
 import verbIsIrregular from '@utilities/propertyTestFunctions/verbIsIrregular';
@@ -42,6 +39,10 @@ export const processVariation = (
 
   if ('partizip' in record && record.partizip) {
     hydratedVerb.partizip = record.partizip;
+  }
+
+  if (particle in record) {
+    console.log('HURRAY');
   }
 
   if (verbIsIrregular(record, [...GERMAN_IRREGULAR_KEYS])) {

--- a/apps/db_management/src/models/german/spec_constants/newVerbsSpec.ts
+++ b/apps/db_management/src/models/german/spec_constants/newVerbsSpec.ts
@@ -179,7 +179,6 @@ export const gelingenGermanVerb: LanguageVerbCandidate = {
   impersonal: true,
   infinitive: 'gelingen',
   dative: true,
-  // weakEndings: true,
   language: LanguageMap.de,
   translations: {
     en: ['succeed (reverse, impersonal)'],
@@ -217,6 +216,62 @@ export const gelingenReturnObject: GermanVerbHydrated = {
       },
       translations: {
         en: ['succeed (reverse, impersonal)'],
+      },
+    },
+  ],
+};
+
+export const brennenGermanVerb: LanguageVerbCandidate = {
+  infinitive: 'brennen',
+  language: LanguageMap.de,
+  translations: {
+    en: ['burn', 'shine', 'distil'],
+  },
+  weakEndings: true,
+  stems: {
+    präteritum: 'a',
+    k2präsens: 'e',
+    partizip: 'a',
+  },
+};
+
+export const brennenReturnObject: GermanVerbHydrated = {
+  infinitive: 'brennen',
+  language: LanguageMap.de,
+  variations: [
+    {
+      hilfsverb: 'haben',
+      partizip: 'gebrannt',
+      translations: {
+        en: ['burn', 'shine', 'distil'],
+      },
+      k2präsens: {
+        '1033': 'brennte',
+        '1041': 'brennten',
+        '1098': 'brenntest',
+        '1106': 'brenntet',
+        '1548': 'brennte',
+      },
+      konjunktiv: {
+        '1033': 'brenne',
+        '1041': 'brennen',
+        '1098': 'brennest',
+        '1106': 'brennet',
+        '1548': 'brenne',
+      },
+      präsens: {
+        '1033': 'brenne',
+        '1041': 'brennen',
+        '1098': 'brennst',
+        '1106': 'brennt',
+        '1548': 'brennt',
+      },
+      präteritum: {
+        '1033': 'brannte',
+        '1041': 'brannten',
+        '1098': 'branntest',
+        '1106': 'branntet',
+        '1548': 'brannte',
       },
     },
   ],

--- a/apps/db_management/src/models/german/spec_constants/specConstants.ts
+++ b/apps/db_management/src/models/german/spec_constants/specConstants.ts
@@ -517,6 +517,14 @@ export const blendenGermanVerb: LanguageVerbCandidate = {
     en: ['blind'],
   },
   hilfsverb: 'haben',
+  variations: [
+    {
+      particle: 'ab',
+      translations: {
+        en: ['fade'],
+      },
+    },
+  ],
 };
 
 export const blendenReturnObject: GermanVerbHydrated = {
@@ -556,6 +564,41 @@ export const blendenReturnObject: GermanVerbHydrated = {
       },
       translations: {
         en: ['blind'],
+      },
+    },
+    {
+      hilfsverb: 'haben',
+      partizip: 'abgeblendet',
+      präsens: {
+        [GermanPronounKeys.ich]: 'blende',
+        [GermanPronounKeys.wir]: 'blenden',
+        [GermanPronounKeys.du]: 'blendest',
+        [GermanPronounKeys.ihr]: 'blendet',
+        [GermanPronounKeys.es]: 'blendet',
+      },
+      präteritum: {
+        [GermanPronounKeys.ich]: 'blendete',
+        [GermanPronounKeys.wir]: 'blendeten',
+        [GermanPronounKeys.du]: 'blendetest',
+        [GermanPronounKeys.ihr]: 'blendetet',
+        [GermanPronounKeys.es]: 'blendete',
+      },
+      konjunktiv: {
+        [GermanPronounKeys.ich]: 'blende',
+        [GermanPronounKeys.wir]: 'blenden',
+        [GermanPronounKeys.du]: 'blendest',
+        [GermanPronounKeys.ihr]: 'blendet',
+        [GermanPronounKeys.es]: 'blende',
+      },
+      k2präsens: {
+        [GermanPronounKeys.ich]: 'blendete',
+        [GermanPronounKeys.wir]: 'blendeten',
+        [GermanPronounKeys.du]: 'blendetest',
+        [GermanPronounKeys.ihr]: 'blendetet',
+        [GermanPronounKeys.es]: 'blendete',
+      },
+      translations: {
+        en: ['fade'],
       },
     },
   ],

--- a/shared-types/german-types/src/germanTypes.ts
+++ b/shared-types/german-types/src/germanTypes.ts
@@ -190,9 +190,11 @@ export interface GermanVerb extends LanguageVerbBase {
   infinitive: string;
   irregular?: GermanIrregularObject;
   partizip?: string;
+  particle?: string;
   seperable?: boolean;
   stems?: { [key in GermanStem]?: string };
   strong?: boolean;
+  translations: TranslationSet;
   variations?: Array<Partial<GermanVerb> | { definition: string }>;
   weakEndings?: boolean;
 }


### PR DESCRIPTION
Added a test for `abbrennen` to  test having particles in the variations object.
Added a last rule to the variation handler for particles, which assumes that all particles prepend.
**This may not be the case.**
Moved all verbs in processDeRecordVerbs.spec.ts into a loop for simplicity.