### PR TITLE
Update de yamls so particles are variations

### DIFF
--- a/apps/db_management/package.json
+++ b/apps/db_management/package.json
@@ -5,6 +5,7 @@
   "main": "src/server.ts",
   "scripts": {
     "test:unit": "npx jest",
+    "group-entries": "sh ./scripts/groupEntries.sh",
     "test:e2e": "echo 0",
     "lint": "eslint",
     "build": "sh scripts/copy-data.sh && tsc && tsc-alias",

--- a/apps/db_management/scripts/groupEntries.js
+++ b/apps/db_management/scripts/groupEntries.js
@@ -1,0 +1,53 @@
+const fs = require('fs');
+const path = require('path');
+const yaml = require('js-yaml');
+
+const args = process.argv;
+const filesArray = args.slice(2);
+
+function groupEntries(_filesArray = filesArray) {
+  const seenVerbs = {};
+  // eslint-disable-next-line no-console
+  console.log({ _filesArray });
+
+  _filesArray.forEach((filePath) => {
+    try {
+      // eslint-disable-next-line no-console
+      console.log(filePath);
+      const fileContents = fs.readFileSync(
+        path.resolve(__dirname, '../src/data', filePath),
+        'utf8',
+      );
+      const data = yaml.load(fileContents);
+      // console.log(Object.entries(data));
+
+      for (const [verb, value] of Object.entries(data)) {
+        const [prefix, baseVerb] = verb.split('|');
+        if (!seenVerbs[baseVerb]) {
+          seenVerbs[baseVerb] = [];
+        }
+
+        if (value.language) {
+          delete value.language;
+        }
+
+        seenVerbs[baseVerb].push({ particle: prefix, ...value });
+      }
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.log(`Error in ${filePath}: ${err} ${__dirname}`);
+    }
+
+    try {
+      fs.writeFileSync(
+        path.resolve(__dirname, '../src/data', 'grouped_' + filePath),
+        yaml.dump(seenVerbs),
+      );
+      // file written successfully
+    } catch (err) {
+      console.error(err);
+    }
+  });
+}
+
+groupEntries();

--- a/apps/db_management/scripts/groupEntries.sh
+++ b/apps/db_management/scripts/groupEntries.sh
@@ -1,0 +1,4 @@
+echo 'hello world'
+echo $@
+
+node scripts/groupEntries.js $@

--- a/apps/db_management/scripts/groupEntries.sh
+++ b/apps/db_management/scripts/groupEntries.sh
@@ -1,4 +1,1 @@
-echo 'hello world'
-echo $@
-
 node scripts/groupEntries.js $@

--- a/apps/db_management/src/data/_germanVerbs2.yaml
+++ b/apps/db_management/src/data/_germanVerbs2.yaml
@@ -9,3 +9,63 @@ wählen:
 blasen: # https://www.coniuno.com/verbtables/german/blasen.html
 gießen: # https://www.germanveryeasy.com/giessen
 spalten: # https://www.coniuno.com/verbtables/german/spalten.html
+
+# what to do with verbs that need more particles?
+ab|hängen von:
+  language: de
+  translations:
+    en: be dependent on
+
+etwas mit|geben:
+  language: de
+  translations:
+    en: give something [for the purpose of taking it along]
+
+jemandem vor|greifen:
+  language: de
+  translations:
+    en: jump in ahead of someone
+
+jemanden hoch|bringen:
+  language: de
+  translations:
+    en: help someone up
+
+auf etwas hinaus|laufen:
+  language: de
+  translations:
+    en: lead to something
+
+kommen mit:
+  - particle: zurecht
+    translations:
+      en: cope with
+  - particle: über etwas hinweg
+    translations:
+      en: get over something
+
+denken:
+  - particle: etwas weg
+    translations:
+      en: imagine that something is not there
+
+leben:
+  - particle: vor sich hin
+    translations:
+      en: live passively, without purpose
+
+sehen [auf]:
+  - particle: herab
+    translations:
+      en: look down (on)
+
+setzen:
+    - particle: sich über etwas hinweg
+      translations:
+        en: disregard something
+    - particle: sich mit jemandem auseinander
+      translations:
+        en: have it out with someone
+    - particle: sich mit etwas auseinander
+      translations:
+        en: come to terms with something

--- a/apps/db_management/src/data/germanSeparable.yaml
+++ b/apps/db_management/src/data/germanSeparable.yaml
@@ -1,33 +1,3 @@
-ab|blenden:
-  language: de
-  translations:
-    en: [fade out, dim (lights)]
-
-ab|brechen:
-  language: de
-  translations:
-    en: break off
-
-ab|brennen:
-  language: de
-  translations:
-    en: burn down
-
-ab|danken:
-  language: de
-  translations:
-    en: [abdicate, resign]
-
-ab|drücken:
-  language: de
-  translations:
-    en: [pull the trigger, shoot]
-
-ab|fahren:
-  language: de
-  translations:
-    en: [drive off,  depart (by car)]
-
 ab|fegen:
   language: de
   translations:
@@ -42,11 +12,6 @@ ab|hängen von:
   language: de
   translations:
     en: be dependent on
-
-ab|hören:
-  language: de
-  translations:
-    en: wiretap
 
 ab|kommen:
   language: de
@@ -2259,37 +2224,9 @@ nach|reichen:
   translations:
     en: hand in later
 
-nach|rücken:
-  language: de
-  translations:
-    en: move up (to the next position after it has become vacant)
 
-nach|schauen / nachsehen:
-  language: de
-  translations:
-    en: [look up, check up
-]
-nach|spielen:
-  language: de
-  translations:
-    en: play during time that has been added on (injury time in soccer)
-
-nach|sprechen:
-  language: de
-  translations:
-    en: repeat after
-
-nach|stellen:
-  language: de
-  translations:
-    en: readjust
 
 nach|trauern:
-  language: de
-  translations:
-    en: mourn or bemoan the passing of
-
-nach|weinen:
   language: de
   translations:
     en: mourn or bemoan the passing of
@@ -2298,11 +2235,6 @@ nach|vollziehen:
   language: de
   translations:
     en: comprehend
-
-nach|weisen:
-  language: de
-  translations:
-    en: provide proof of something that has been committed
 
 nach|wirken:
   language: de
@@ -2314,100 +2246,20 @@ nach|zählen:
   translations:
     en: recount (count again)
 
-nebenher|fahren:
-  language: de
-  translations:
-    en: drive alongside
-
-nebenher|gehen:
-  language: de
-  translations:
-    en: walk alongside
-
-nebenher|laufen:
-  language: de
-  translations:
-    en: run alongside, proceed at the same time
-
-nieder|brennen:
-  language: de
-  translations:
-    en: burn down
-
 nieder|brüllen:
   language: de
   translations:
     en: shout down
-
-nieder|gehen:
-  language: de
-  translations:
-    en: [drop down, go down, land]
-
-nieder|halten:
-  language: de
-  translations:
-    en: oppress
 
 nieder|knien:
   language: de
   translations:
     en: kneel down
 
-nieder|lassen:
-  language: de
-  translations:
-    en: lower
-
-sich nieder|lassen:
-  language: de
-  translations:
-    en: ensconce oneself
-
-nieder|reißen:
-  language: de
-  translations:
-    en: tear down
-
-nieder|schießen:
-  language: de
-  translations:
-    en: gun down
-
-nieder|schlagen:
-  language: de
-  translations:
-    en: [knock down, suppress, make despondent]
-
-nieder|werfen:
-  language: de
-  translations:
-    en: [overcome, defeat]
-
-sich nieder|werfen:
-  language: de
-  translations:
-    en: prostrate oneself
-
-statt|finden:
-  language: de
-  translations:
-    en: take place
-
-statt|geben:
-  language: de
-  translations:
-    en: [accede to, grant, allow]
-
 um|ändern:
   language: de
   translations:
     en: change, change around
-
-um|arbeiten:
-  language: de
-  translations:
-    en: rework
 
 um|benennen:
   language: de
@@ -2419,35 +2271,10 @@ um|blicken:
   translations:
     en: look around
 
-um|bringen:
-  language: de
-  translations:
-    en: kill
-
 um|buchen:
   language: de
   translations:
     en: re-book (travel plans)
-
-um|denken:
-  language: de
-  translations:
-    en: [rethink, revise one's opinion]
-
-um|drehen:
-  language: de
-  translations:
-    en: turn around
-
-um|fallen:
-  language: de
-  translations:
-    en: [fall over, fall down]
-
-um|fassen:
-  language: de
-  translations:
-    en: [grasp, include, embrace]
 
 um|formen:
   language: de
@@ -2464,16 +2291,6 @@ um|funktionieren:
   translations:
     en: change the function of
 
-um|graben:
-  language: de
-  translations:
-    en: dig over to turn over (dirt)
-
-um|hängen:
-  language: de
-  translations:
-    en: re-hang (curtains), drape around
-
 um|hauen:
   language: de
   translations:
@@ -2483,6 +2300,11 @@ um|kehren:
   language: de
   translations:
     en: turn around
+
+wieder|kehren:
+  language: de
+  translations:
+    en: return
 
 um|kippen:
   language: de
@@ -2494,25 +2316,10 @@ um|klammern:
   translations:
     en: clutch
 
-um|kommen:
-  language: de
-  translations:
-    en: get killed
-
 um|kreisen:
   language: de
   translations:
     en: orbit
-
-um|laden:
-  language: de
-  translations:
-    en: transfer (a load)
-
-um|lernen:
-  language: de
-  translations:
-    en: learn to think differently
 
 um|rahmen:
   language: de
@@ -2534,16 +2341,6 @@ um|schalten:
   translations:
     en: change, switch (gears, channels)
 
-um|setzen:
-  language: de
-  translations:
-    en: transfer, transpose, implement, transact, transform
-
-um|steigen:
-  language: de
-  translations:
-    en: transfer [change buses, trains, planes]
-
 um|stimmen:
   language: de
   translations:
@@ -2559,60 +2356,10 @@ um|spulen:
   translations:
     en: rewind
 
-um|stellen:
-  language: de
-  translations:
-    en: rearrange
-
 um|tauschen:
   language: de
   translations:
     en: exchange
-
-um|werfen:
-  language: de
-  translations:
-    en: knock over
-
-um|ziehen:
-  language: de
-  translations:
-    en: move (to change address)
-
-sich um|ziehen:
-  language: de
-  translations:
-    en: change clothes
-
-sich um|hören:
-  language: de
-  translations:
-    en: keep one's ears open
-
-sich um|fragen:
-  language: de
-  translations:
-    en: ask around
-
-sich um|sehen:
-  language: de
-  translations:
-    en: look around
-
-sich um|schauen:
-  language: de
-  translations:
-    en: look around
-
-sich vor|arbeiten:
-  language: de
-  translations:
-    en: work one's way forward
-
-vor|bauen:
-  language: de
-  translations:
-    en: make provision
 
 vor|behalten:
   language: de
@@ -2629,70 +2376,20 @@ vor|beugen:
   translations:
     en: [prevent, bend forward]
 
-vor|bringen:
-  language: de
-  translations:
-    en: propose, bring forward, produce
-
 vor|drängen:
   language: de
   translations:
     en: push forward
-
-vor|fahren:
-  language: de
-  translations:
-    en: drive on ahead, drive up in front (of a building)
-
-vor|fallen:
-  language: de
-  translations:
-    en: happen
-
-vor|führen:
-  language: de
-  translations:
-    en: bring forward, perform
-
-vor|geben:
-  language: de
-  translations:
-    en: pretend
-
-vor|gehen:
-  language: de
-  translations:
-    en: proceed, go first
-
-vor|legen:
-  language: de
-  translations:
-    en: present
 
 jemandem vor|greifen:
   language: de
   translations:
     en: jump in ahead of someone
 
-vor|haben:
-  language: de
-  translations:
-    en: intend
-
 vor|herrschen:
   language: de
   translations:
     en: predominate
-
-vor|kommen:
-  language: de
-  translations:
-    en: happen, seem
-
-vor|laden:
-  language: de
-  translations:
-    en: summon
 
 vor|neigen:
   language: de
@@ -2704,140 +2401,21 @@ vor|programmieren:
   translations:
     en: pre-program
 
-vor|rücken:
-  language: de
-  translations:
-    en: move forward
 
-vor|schlagen:
-  language: de
-  translations:
-    en: propose, suggest
-
-vor|setzen:
-  language: de
-  translations:
-    en: put before
-
-vor|singen:
-  language: de
-  translations:
-    en: sing (in front of people)
-
-vor|sorge:
+vor|sorgen:
   language: de
   translations:
     en: make provisions
-
-vor|spielen:
-  language: de
-  translations:
-    en: play (music in front of people)
-
-vor|tragen:
-  language: de
-  translations:
-    en: perform, present (a speech, song, etc.)
-
-vor|ziehen:
-  language: de
-  translations:
-    en: prefer, pull forward,  draw [a curtain]
 
 voraus|berechnen:
   language: de
   translations:
     en: calculate in advance
 
-voraus|gehen:
-  language: de
-  translations:
-    en: go on ahead
-
-voraus|sagen:
-  language: de
-  translations:
-    en: predict
-
-voraus|sehen:
-  language: de
-  translations:
-    en: foresee
-
-voraus|sein:
-  language: de
-  translations:
-    en: be in advance, be ahead
-
-voraus|setzen:
-  language: de
-  translations:
-    en: assume
-
-vorbei|fahren:
-  language: de
-  translations:
-    en: drive past
-
-vorbei|gehen:
-  language: de
-  translations:
-    en: walk past
-
-vorbei|kommen:
-  language: de
-  translations:
-    en: drop in
-
-vorbei|lassen:
-  language: de
-  translations:
-    en: let by
-
-vorbei|reden:
-  language: de
-  translations:
-    en: talk past
-
-vorbei|schießen:
-  language: de
-  translations:
-    en: miss (the target)
-
 vorüber|eilen:
   language: de
   translations:
     en: hurry past
-
-vorüber|fahren:
-  language: de
-  translations:
-    en: drive by
-
-vorüber|fliegen:
-  language: de
-  translations:
-    en: fly by
-
-vorüber|gehen:
-  language: de
-  translations:
-    en: go by
-
-vorüber|ziehen:
-  language: de
-  translations:
-    en: pass by
-
-vorweg|nehmen:
-  language: de
-  translations:
-    en: anticipate, pre-empt, forestall
-
-vorweg|sagen:
-  language: de
-  translations:
-    en: say in anticipation
 
 vorweg|schicken:
   language: de
@@ -2849,185 +2427,30 @@ weg|blasen:
   translations:
     en: blow away
 
-weg|bleiben:
-  language: de
-  translations:
-    en: stay away
-
-weg|bringen:
-  language: de
-  translations:
-    en: take away
-
 etwas weg|denken:
   language: de
   translations:
     en: imagine that something is not there
-
-weg|fahren:
-  language: de
-  translations:
-    en: drive off
 
 weg|fegen:
   language: de
   translations:
     en: sweep away
 
-weg|führen:
-  language: de
-  translations:
-    en: lead off
-
-weg|geben:
-  language: de
-  translations:
-    en: give away
-
-weg|gehen:
-  language: de
-  translations:
-    en: go away
-
 weg|jagen:
   language: de
   translations:
     en: chase away
-
-weg|kommen:
-  language: de
-  translations:
-    en: get away
-
-weg|können:
-  language: de
-  translations:
-    en: [be able to get away, be able to leave]
-
-weg|laufen:
-  language: de
-  translations:
-    en: run away
-
-weg|müssen:
-  language: de
-  translations:
-    en: have to leave
-
-weg|räumen:
-  language: de
-  translations:
-    en: clear away
-
-weg|sehen:
-  language: de
-  translations:
-    en: look away
-
-weg|stecken:
-  language: de
-  translations:
-    en: [put away, withstand (a blow)]
-
-weg|werfen:
-  language: de
-  translations:
-    en: throw away
-
-weg|wischen:
-  language: de
-  translations:
-    en: erase, wipe away
-
-weg|ziehen:
-  language: de
-  translations:
-    en: move away, pull away
-
-weiter|bestehen:
-  language: de
-  translations:
-    en: continue to exist
-
-weiter|entwickeln:
-  language: de
-  translations:
-    en: develop further
-
-weiter|erzählen:
-  language: de
-  translations:
-    en: tell further, continue a narration
-
-weiter|führen:
-  language: de
-  translations:
-    en: continue
-
-weiter|gehen:
-  language: de
-  translations:
-    en: move along
-
-weiter|kommen:
-  language: de
-  translations:
-    en: [get further, make progress]
-
-weiter|leben:
-  language: de
-  translations:
-    en: continue living
-
-weiter|machen:
-  language: de
-  translations:
-    en: carry on
-
-weiter|reden:
-  language: de
-  translations:
-    en: continue talking
-
-weiter|sprechen:
-  language: de
-  translations:
-    en: continue talking
-
-weiter|sagen:
-  language: de
-  translations:
-    en: pass (the word) on
-
-weiter|ziehen:
-  language: de
-  translations:
-    en: move along
-
-wieder|bekommen:
-  language: de
-  translations:
-    en: get back
 
 wieder|beleben:
   language: de
   translations:
     en: resuscitate
 
-wieder|bringen:
-  language: de
-  translations:
-    en: bring back
-
 wieder|entdecken:
   language: de
   translations:
     en: rediscover
-
-wieder|geben:
-  language: de
-  translations:
-    en: give back, repeat
 
 wieder|herstellen:
   language: de
@@ -3044,255 +2467,40 @@ wieder|käuen:
   translations:
     en: ruminate
 
-wieder|kehren:
-  language: de
-  translations:
-    en: return
-
-wieder|sehen:
-  language: de
-  translations:
-    en: see again
-
 wieder|vereinigen:
   language: de
   translations:
     en: reunite
-
-zu|bauen:
-  language: de
-  translations:
-    en: block off
 
 zu|billigen:
   language: de
   translations:
     en: grant, allow
 
-zu|binden:
-  language: de
-  translations:
-    en: tie, tie up
-
-zu|bringen:
-  language: de
-  translations:
-    en: bring
-
-zu|decken:
-  language: de
-  translations:
-    en: cover up, tuck in
-
-zu|drücken:
-  language: de
-  translations:
-    en: press shut
-
-zu|erkennen:
-  language: de
-  translations:
-    en: [bestow, confer (on)]
-
-zu|fahren:
-  language: de
-  translations:
-    en: [drive towards, ride towards]
-
-zu|fassen:
-  language: de
-  translations:
-    en: grab at
-
-zu|fließen:
-  language: de
-  translations:
-    en: flow toward
-
-zu|gehören:
-  language: de
-  translations:
-    en: belong to
-
-zu|geben:
-  language: de
-  translations:
-    en: admit to, confess
-
-zu|greifen:
-  language: de
-  translations:
-    en: [take hold, help oneself (to something)]
-
-zu|kommen:
-  language: de
-  translations:
-    en: approach
-
-zu|lassen:
-  language: de
-  translations:
-    en: authorize
-
-zu|machen:
-  language: de
-  translations:
-    en: close
-
-zu|nehmen:
-  language: de
-  translations:
-    en: increase, gain weight
-
-zu|ziehen:
-  language: de
-  translations:
-    en: pull shut
-
-sich zurecht|finden:
-  language: de
-  translations:
-    en: [find one's way, get one's bearings]
-
 zurecht|kommen mit:
   language: de
   translations:
     en: cope with
-
-zurecht|legen:
-  language: de
-  translations:
-    en: lay out in readiness
-
-zurecht|machen:
-  language: de
-  translations:
-    en: get (something) ready
-
-zurecht|weisen:
-  language: de
-  translations:
-    en: rebuke, reprimand
-
-zurück|bleiben:
-  language: de
-  translations:
-    en: stay behind
-
-zurück|blenden:
-  language: de
-  translations:
-    en: flash back (film)
-
-zurück|drehen:
-  language: de
-  translations:
-    en: turn back
-
-zurück|erhalten:
-  language: de
-  translations:
-    en: get back, be given back
 
 zurück|erobern:
   language: de
   translations:
     en: recapture
 
-zurück|führen:
-  language: de
-  translations:
-    en: trace back
-
-zurück|geben:
-  language: de
-  translations:
-    en: give back, return
-
-zurück|müssen:
-  language: de
-  translations:
-    en: go back, return
-
-zurück|gehen:
-  language: de
-  translations:
-    en: have to go back
-
 zurück|lehnen:
   language: de
   translations:
     en: lean back
-
-zurück|schlagen:
-  language: de
-  translations:
-    en: hit back, strike back
 
 zurück|schrecken:
   language: de
   translations:
     en: shrink back, shrink from, recoil
 
-zurück|setzen:
-  language: de
-  translations:
-    en: reverse, put back
-
-zurück|weisen:
-  language: de
-  translations:
-    en: refuse, send back
-
-zusammen|arbeiten:
-  language: de
-  translations:
-    en: work together
-
-zusammen|beißen:
-  language: de
-  translations:
-    en: bite together
-
-zusammen|bauen:
-  language: de
-  translations:
-    en: assemble
-
-zusammen|fassen:
-  language: de
-  translations:
-    en: summarize
-
-zusammen|führen:
-  language: de
-  translations:
-    en: bring together
-
-zusammen|gehören:
-  language: de
-  translations:
-    en: belong together
-
 zusammen|klappen:
   language: de
   translations:
     en: fold up, shut
-
-zusammen|kommen:
-  language: de
-  translations:
-    en: meet, come together
-
-zusammen|passen:
-  language: de
-  translations:
-    en: be suited for each other
-
-zusammen|setzen:
-  language: de
-  translations:
-    en: seat/put together
 
 zusammen|stoßen:
   language: de
@@ -3304,18 +2512,3 @@ zusammen|zählen:
   translations:
     en: add up
 
-zusammen|ziehen:
-  language: de
-  translations:
-    en: pull together
-
-ab|warten:
-  language: de
-  translations:
-    en: bide
-
-aus|weichen:
-  language: de
-  dative: true
-  translations:
-    en: evade

--- a/apps/db_management/src/data/germanSeparable.yaml
+++ b/apps/db_management/src/data/germanSeparable.yaml
@@ -1,3 +1,98 @@
+hinein|reichen:
+  language: de
+  translations:
+    en: reach into
+hin|reichen:
+  language: de
+  translations:
+    en: suffice
+aus|reichen:
+  language: de
+  translations:
+    en: be sufficient
+nach|reichen:
+  language: de
+  translations:
+    en: hand in later
+
+wieder|holen:
+  language: de
+  translations:
+    en: repeat
+nach|holen:
+  language: de
+  translations:
+    en: [catch up on, make up for, fetch later]
+herunter|holen:
+  language: de
+  translations:
+    en: fetch down
+herein|holen:
+  language: de
+  translations:
+    en: bring in
+herbei|holen:
+  language: de
+  translations:
+    en: fetch
+
+hinein|drängen:
+  language: de
+  translations:
+    en: fall into
+vor|drängen:
+  language: de
+  translations:
+    en: push forward
+
+zurück|lehnen:
+  language: de
+  translations:
+    en: lean back
+an|lehnen:
+  language: de
+  translations:
+    en: lean
+
+fort|treiben:
+  language: de
+  translations:
+    en: [drive away, drift away, continue on with]
+ab|treiben:
+  language: de
+  translations:
+    en: abort
+
+um|stimmen:
+  language: de
+  translations:
+    en: persuade [to change one's mind]
+ab|stimmen:
+  language: de
+  translations:
+    en: vote
+
+ab|schicken:
+  language: de
+  translations:
+    en: send off
+vorweg|schicken:
+  language: de
+  translations:
+    en: send off in anticipation
+hinterher|schicken:
+  language: de
+  translations:
+    en: [send after, send on]
+hin|schicken:
+  language: de
+  translations:
+    en: send there
+herüber|schicken:
+  language: de
+  translations:
+    en: send over here
+
 ab|fegen:
   language: de
   translations:
@@ -8,25 +103,10 @@ ab|hacken:
   translations:
     en: chop off
 
-ab|hängen von:
-  language: de
-  translations:
-    en: be dependent on
-
-ab|kommen:
-  language: de
-  translations:
-    en: get away
-
 ab|lenken:
   language: de
   translations:
     en: divert
-
-ab|nehmen:
-  language: de
-  translations:
-    en: [remove, take away]
 
 ab|nutzen:
   language: de
@@ -38,120 +118,40 @@ ab|riegeln:
   translations:
     en: [bolt (a door), close off]
 
-ab|schaffen:
-  language: de
-  translations:
-    en: do away with
-
-ab|schicken:
-  language: de
-  translations:
-    en: send off
-
 ab|sichern:
   language: de
   translations:
     en: secure
-
-ab|stimmen:
-  language: de
-  translations:
-    en: vote
-
-ab|treiben:
-  language: de
-  translations:
-    en: abort
 
 ab|wehren:
   language: de
   translations:
     en: [repulse, fend off]
 
-ab|ziehen:
-  language: de
-  translations:
-    en: deduct, withdraw
-
 ab|zweigen:
   language: de
   translations:
     en: branch off
-
-an|bauen:
-  language: de
-  translations:
-    en: [build on, add, cultivate (a crop)]
-
-an|beißen:
-  language: de
-  translations:
-    en: take a bite of
-
-an|binden:
-  language: de
-  translations:
-    en: attach
-
-an|bringen:
-  language: de
-  translations:
-    en: [fasten, install]
 
 an|dauern:
   language: de
   translations:
     en: last, continue
 
-an|fahren:
-  language: de
-  translations:
-    en: [drive up, arrive (by car)]
-
 an|fassen:
   language: de
   translations:
     en: take hold of
-
-an|hängen:
-  language: de
-  translations:
-    en: attach
-
-an|greifen:
-  language: de
-  translations:
-    en: attack
-
-an|haben:
-  language: de
-  translations:
-    en: [have on, wear]
 
 an|halten:
   language: de
   translations:
     en: cause to stop
 
-an|kommen:
-  language: de
-  translations:
-    en: arrive
-
 an|lächeln:
   language: de
   translations:
     en: smile at
-
-an|lehnen:
-  language: de
-  translations:
-    en: lean
-
-an|machen:
-  language: de
-  translations:
-    en: [attach, make a pass at]
 
 an|merken:
   language: de
@@ -178,10 +178,7 @@ an|schießen:
   translations:
     en: shoot at and wound
 
-an|schauen:
-  language: de
-  translations:
-    en: look at
+
 
 an|schneiden:
   language: de
@@ -208,35 +205,10 @@ an|tippen:
   translations:
     en: give a light tap to
 
-an|zeigen:
-  language: de
-  translations:
-    en: report to the authorities, show
-
-an|ziehen:
-  language: de
-  translations:
-    en: attract, put on
-
 an|zünden:
   language: de
   translations:
     en: ignite
-
-auf|arbeiten:
-  language: de
-  translations:
-    en: finish off, reuse
-
-auf|atmen:
-  language: de
-  translations:
-    en: breathe a sigh of relief
-
-auf|bauen:
-  language: de
-  translations:
-    en: build up
 
 auf|bessern:
   language: de
@@ -247,11 +219,6 @@ auf|bewahren:
   language: de
   translations:
     en: keep, store
-
-auf|binden:
-  language: de
-  translations:
-    en: untie, undo
 
 auf|blühen:
   language: de
@@ -283,11 +250,7 @@ auf|essen:
   translations:
     en: eat up
 
-auf|fallen:
-  language: de
-  dative: true
-  translations:
-    en: stand out, be noticeable
+
 
 auf|fassen:
   language: de
@@ -299,25 +262,11 @@ auf|fliegen:
   translations:
     en: fly up
 
-auf|geben:
-  language: de
-  translations:
-    en: give up
-
 auf|klären:
   language: de
   translations:
     en: enlighten
 
-auf|kommen:
-  language: de
-  translations:
-    en: arise, spring for [costs]
-
-auf|machen:
-  language: de
-  translations:
-    en: open
 
 auf|passen:
   language: de
@@ -349,10 +298,6 @@ auf|schneiden:
   translations:
     en: cut open
 
-auf|schreiben:
-  language: de
-  translations:
-    en: write down
 
 auf|sein:
   language: de
@@ -369,20 +314,10 @@ auf|weichen:
   translations:
     en: soften up
 
-auf|ziehen:
-  language: de
-  translations:
-    en: wind up, raise [children]
-
 auf|zwingen:
   language: de
   translations:
     en: force upon).
-
-aus|bauen:
-  language: de
-  translations:
-    en: extend, improve, expand
 
 aus|bessern:
   language: de
@@ -394,15 +329,7 @@ aus|beuten:
   translations:
     en: exploit
 
-aus|bilden:
-  language: de
-  translations:
-    en: train
 
-aus|bleiben:
-  language: de
-  translations:
-    en: stay away, fail to show up
 
 aus|breiten:
   language: de
@@ -424,16 +351,6 @@ aus|diskutieren:
   translations:
     en: discuss thoroughly
 
-aus|fahren:
-  language: de
-  translations:
-    en: go for a drive, take for a drive
-
-aus|fallen:
-  language: de
-  translations:
-    en: fail, drop out, be canceled
-
 aus|führen:
   language: de
   translations:
@@ -444,11 +361,6 @@ aus|füllen:
   translations:
     en: fill out [a form]
 
-aus|gehen:
-  language: de
-  translations:
-    en: go out
-
 aus|gleichen:
   language: de
   translations:
@@ -458,11 +370,6 @@ aus|halten:
   language: de
   translations:
     en: endure, withstand
-
-aus|helfen:
-  language: de
-  translations:
-    en: help out
 
 aus|klammern:
   language: de
@@ -484,11 +391,6 @@ aus|leihen:
   translations:
     en: lend
 
-aus|machen:
-  language: de
-  translations:
-    en: turn off, extinguish, make a difference, add up to
-
 aus|pressen:
   language: de
   translations:
@@ -504,10 +406,7 @@ aus|radieren:
   translations:
     en: erase
 
-aus|reichen:
-  language: de
-  translations:
-    en: be sufficient
+
 
 aus|richten:
   language: de
@@ -559,15 +458,9 @@ auseinander|brechen:
   translations:
     en: break up, break apart
 
-auseinander|fallen:
-  language: de
-  translations:
-    en: fall apart
 
-auseinander|gehen:
-  language: de
-  translations:
-    en: part, disperse
+
+
 
 auseinander|haltem:
   language: de
@@ -589,20 +482,12 @@ bei|behalten:
   translations:
     en: retain
 
-bei|bringen:
-  language: de
-  translations:
-    en: teach
-
 bei|fügen:
   language: de
   translations:
     en: enclose [along with]
 
-bei|kommen:
-  language: de
-  translations:
-    en: get hold of, deal with
+
 
 bei|liegen:
   language: de
@@ -634,11 +519,6 @@ bei|wohnen:
   translations:
     en: be present at
 
-dabei|bleiben:
-  language: de
-  translations:
-    en: stay there, stick with
-
 dabei|sein:
   language: de
   translations:
@@ -654,45 +534,10 @@ dabei|stehen:
   translations:
     en: sit/stand there, stick with
 
-da|bleiben:
-  language: de
-  translations:
-    en: stay there
-
-da|lassen:
-  language: de
-  translations:
-    en: leave there
-
-sich dar|anmachen:
-  language: de
-  translations:
-    en: set about it, get down to it
-
-dahinter|kommen:
-  language: de
-  translations:
-    en: find out
-
-dazwischen|reden:
-  language: de
-  translations:
-    en: interrupt
-
-durch|arbeiten:
-  language: de
-  translations:
-    en: work through
-
 durch|brechen:
   language: de
   translations:
     en: break through
-
-durch|atmen:
-  language: de
-  translations:
-    en: breathe deeply
 
 durch|braten:
   language: de
@@ -704,25 +549,12 @@ durch|drehen:
   translations:
     en: put through a grinder
 
-durch|gehen:
-  language: de
-  translations:
-    en: walk through
 
-sich durch|finden:
-  language: de
-  translations:
-    en: find one's way through
 
 durch|halten:
   language: de
   translations:
     en: withstand, endure
-
-durch|fahren:
-  language: de
-  translations:
-    en: drive straight through
 
 durch|führen:
   language: de
@@ -734,10 +566,7 @@ durch|kämmen:
   translations:
     en: comb through [hair]
 
-durch|lassen:
-  language: de
-  translations:
-    en: allow through
+
 
 durch|schlüpfen:
   language: de
@@ -764,11 +593,6 @@ durch|wählen:
   translations:
     en: dial directly
 
-durch|ziehen:
-  language: de
-  translations:
-    en: pull through [an opening]).
-
 ein|berufen:
   language: de
   translations:
@@ -788,16 +612,6 @@ ein|dringen:
   language: de
   translations:
     en: enter forcibly into
-
-ein|fahren:
-  language: de
-  translations:
-    en: drive in
-
-ein|gehen:
-  language: de
-  translations:
-    en: enter, sink in, shrink
 
 ein|kalkulieren:
   language: de
@@ -824,11 +638,6 @@ ein|laden:
   translations:
     en: invite
 
-ein|lassen:
-  language: de
-  translations:
-    en: allow to enter
-
 ein|leiten:
   language: de
   translations:
@@ -849,11 +658,6 @@ ein|parken:
   translations:
     en: park [in a parking space]
 
-ein|reden:
-  language: de
-  translations:
-    en: pursuade
-
 ein|sacken:
   language: de
   translations:
@@ -868,11 +672,6 @@ ein|schneiden:
   language: de
   translations:
     en: make a cut in
-
-ein|schreiben:
-  language: de
-  translations:
-    en: enroll
 
 ein|schreiten:
   language: de
@@ -919,11 +718,6 @@ ein|zahlen:
   translations:
     en: pay in, pay a deposit).
 
-sich empor|arbeiten:
-  language: de
-  translations:
-    en: work one's way up
-
 empor|blicken:
   language: de
   translations:
@@ -954,21 +748,6 @@ empor|streben:
   translations:
     en: aspire
 
-entgegen|arbeiten:
-  language: de
-  translations:
-    en: work against
-
-entgegen|kommen:
-  language: de
-  translations:
-    en: [approach, accommodate, meet halfway]
-
-entgegen|nehmen:
-  language: de
-  translations:
-    en: [accept, receive]
-
 entgegen|setzen:
   language: de
   translations:
@@ -989,25 +768,15 @@ entgegen|wirken:
   translations:
     en: counteract
 
-entlang|gehen:
-  language: de
-  translations:
-    en: [go along, walk along]
 
-entlang|laufen:
-  language: de
-  translations:
-    en: [go along, walk along]
+
 
 entzwei|brechen:
   language: de
   translations:
     en: break in two
 
-entzwei|gehen:
-  language: de
-  translations:
-    en: come apart
+
 
 entzwei|reißen:
   language: de
@@ -1024,10 +793,7 @@ fehl|besetzen:
   translations:
     en: miscast [in film or theater]
 
-fehl|gehen:
-  language: de
-  translations:
-    en: go wrong
+
 
 fehl|starten:
   language: de
@@ -1054,11 +820,6 @@ fern|sehen:
   translations:
     en: watch television
 
-fest|beißen:
-  language: de
-  translations:
-    en: bite into firmly
-
 fest|frieren:
   language: de
   translations:
@@ -1074,95 +835,41 @@ fest|kleben:
   translations:
     en: [glue on, be glued on]
 
-fest|laufen:
-  language: de
-  translations:
-    en: run aground
-
-fest|legen:
-  language: de
-  translations:
-    en: establish
-
-fest|machen:
-  language: de
-  translations:
-    en: fasten firmly
-
 fest|nageln:
   language: de
   translations:
     en: nail down
-
-fest|nehmen:
-  language: de
-  translations:
-    en: arrest
 
 fest|sitzen:
   language: de
   translations:
     en: be stuck
 
-sich fortbewegen:
+sich fort|bewegen:
   language: de
   translations:
     en: [move along, move on]
 
-fort|bilden:
-  language: de
-  translations:
-    en: continue (one's) education
-
-fort|bringen:
-  language: de
-  translations:
-    en: take away (for repair)
-
-sich fortentwickeln:
+sich fort|entwickeln:
   language: de
   translations:
     en: continue to develop
 
-fort|fahren:
-  language: de
-  translations:
-    en: continue
-
-fort|laufen:
-  language: de
-  translations:
-    en: run away
 
 fort|pflanzen:
   language: de
   translations:
     en: propagate
 
-fort|reden:
-  language: de
-  translations:
-    en: continue talking
-
 fort|setzen:
   language: de
   translations:
     en: [continue, carry on with, resume]
 
-fort|treiben:
-  language: de
-  translations:
-    en: [drive away, drift away, continue on with]
-
 frei|bekommen:
   language: de
   translations:
     en: [get time off]
-
-frei|geben:
-  language: de
-  translations:
-    en: [release (a prisoner), allow (a currency) to float]
 
 frei|halten:
   language: de
@@ -1178,16 +885,6 @@ frei|kaufen:
   language: de
   translations:
     en: [ransom, buy (a slave's) freedom]
-
-frei|kommen:
-  language: de
-  translations:
-    en: [escape, get away]
-
-frei|legen:
-  language: de
-  translations:
-    en: uncover
 
 frei|setzen:
   language: de
@@ -1214,21 +911,6 @@ gegenüber|stellen:
   translations:
     en: [confront, compare]
 
-gleich|bleiben:
-  language: de
-  translations:
-    en: stay the same
-
-gleich|kommen:
-  language: de
-  translations:
-    en: [equal, be tantamount to]
-
-gleich|machen:
-  language: de
-  translations:
-    en: make equal
-
 gleich|setzen:
   language: de
   translations:
@@ -1239,30 +921,10 @@ heim|begleiten:
   translations:
     en: accompany home
 
-heim|fahren:
-  language: de
-  translations:
-    en: drive home
-
-heim|finden:
-  language: de
-  translations:
-    en: find one's way home
-
-heim|gehen:
-  language: de
-  translations:
-    en: go/walk home
-
 heim|kehren:
   language: de
   translations:
     en: return home
-
-heim|kommen:
-  language: de
-  translations:
-    en: come home
 
 heim|suchen:
   language: de
@@ -1279,40 +941,23 @@ her|bestellen:
   translations:
     en: summon
 
-her|fahren:
-  language: de
-  translations:
-    en: [travel here, drive here]
-
 her|führen:
   language: de
   translations:
     en: [bring here, lead here]
 
-her|kommen:
-  language: de
-  translations:
-    en: [come here, come from]
 
 her|tragen:
   language: de
   translations:
     en: carry (to) here (in this direction)
 
-herab|fallen:
-  language: de
-  translations:
-    en: fall from
-
 herab|fließen:
   language: de
   translations:
     en: flow down
 
-herab|hängen:
-  language: de
-  translations:
-    en: hang down
+
 
 herab|setzen:
   language: de
@@ -1344,35 +989,15 @@ herab|stürzen:
   translations:
     en: plummet down
 
-heran|bringen:
-  language: de
-  translations:
-    en: [bring toward, bring up to (a certain point)]
-
 heran|führen:
   language: de
   translations:
     en: [bring up (to a place), lead here]
 
-heran|gehen:
-  language: de
-  translations:
-    en: go up closer
-
-heran|kommen:
-  language: de
-  translations:
-    en: draw near
-
 heran|reifen:
   language: de
   translations:
     en: mature
-
-herauf|arbeiten:
-  language: de
-  translations:
-    en: work one's way up
 
 herauf|beschwören:
   language: de
@@ -1389,30 +1014,16 @@ herauf|tragen:
   translations:
     en: carry up here
 
-herauf|ziehen:
-  language: de
-  translations:
-    en: [pull up, approach]
+
 
 heraus|bitten:
   language: de
   translations:
     en: ask (someone) to come outside
 
-heraus|bringen:
-  language: de
-  translations:
-    en: [bring out, publish, launch, make known]
 
-heraus|fahren:
-  language: de
-  translations:
-    en: drive out of
 
-heraus|geben:
-  language: de
-  translations:
-    en: [hand over, hand out]
+
 
 heraus|hängen:
   language: de
@@ -1434,35 +1045,13 @@ sich heraus|stellen:
   translations:
     en: turn out (to be)
 
-heraus|ziehen:
-  language: de
-  translations:
-    en: pull out
 
-herbei|bringen:
-  language: de
-  translations:
-    en: bring over
 
-herbei|holen:
-  language: de
-  translations:
-    en: fetch
-
-herbei|laufen:
-  language: de
-  translations:
-    en: to come running up
 
 herbei|rufen:
   language: de
   translations:
     en: call over
-
-herbei|schaffen:
-  language: de
-  translations:
-    en: get
 
 herbei|sehnen:
   language: de
@@ -1474,25 +1063,8 @@ herein|bitten:
   translations:
     en: invite in
 
-herein|bringen:
-  language: de
-  translations:
-    en: bring in
 
-herein|fallen:
-  language: de
-  translations:
-    en: fall into, be duped
 
-herein|holen:
-  language: de
-  translations:
-    en: bring in
-
-herein|kommen:
-  language: de
-  translations:
-    en: come in
 
 herein|schneien:
   language: de
@@ -1504,50 +1076,15 @@ herein|spazieren:
   translations:
     en: stroll in
 
-herüber|fahren:
-  language: de
-  translations:
-    en: drive over here
-
-herüber|kommen:
-  language: de
-  translations:
-    en: come over here
-
-herüber|schauen:
-  language: de
-  translations:
-    en: look over here
-
-herüber|schicken:
-  language: de
-  translations:
-    en: send over here
-
 herunter|bekommen:
   language: de
   translations:
     en: [be able to eat, manage to get down]
 
-herunter|fallen:
-  language: de
-  translations:
-    en: fall down
-
 herunter|handeln:
   language: de
   translations:
     en: bargain down
-
-herunter|holen:
-  language: de
-  translations:
-    en: fetch down
-
-herunter|kommen:
-  language: de
-  translations:
-    en: come down (go to the dogs)
 
 herunter|schlucken:
   language: de
@@ -1563,11 +1100,6 @@ herunter|steigen:
   language: de
   translations:
     en: climb down
-
-hervor|gehen:
-  language: de
-  translations:
-    en: emerge, lure out
 
 hervor|heben:
   language: de
@@ -1604,11 +1136,6 @@ sich hervor|wagen:
   translations:
     en: dare to come out
 
-hin|arbeiten:
-  language: de
-  translations:
-    en: work towards
-
 hin|bekommen:
   language: de
   translations:
@@ -1634,40 +1161,19 @@ hin|blättern:
   translations:
     en: shell out
 
-hin|bringen:
-  language: de
-  translations:
-    en: take there
+
 
 hin|deuten:
   language: de
   translations:
     en: point to
 
-hin|fahren:
-  language: de
-  translations:
-    en: go/drive there
-
-hin|fallen:
-  language: de
-  translations:
-    en: fall down
-
-hin|finden:
-  language: de
-  translations:
-    en: find one's way to
-
 hin|führen:
   language: de
   translations:
     en: lead to
 
-hin|geben:
-  language: de
-  translations:
-    en: devote, sacrifice
+
 
 hin|geraten:
   language: de
@@ -1689,11 +1195,6 @@ hin|knien:
   translations:
     en: kneel down
 
-hin|kommen:
-  language: de
-  translations:
-    en: get there
-
 hin|kriegen:
   language: de
   translations:
@@ -1704,25 +1205,11 @@ vor sich hin|leben:
   translations:
     en: live passively, without purpose
 
-hin|legen:
-  language: de
-  translations:
-    en: lay down
 
 hin|lenken:
   language: de
   translations:
     en: steer toward
-
-hin|nehmen:
-  language: de
-  translations:
-    en: accept, put up with
-
-hin|reichen:
-  language: de
-  translations:
-    en: suffice
 
 hin|reißen:
   language: de
@@ -1733,11 +1220,6 @@ hin|richten:
   language: de
   translations:
     en: [execute, put to death]
-
-hin|schicken:
-  language: de
-  translations:
-    en: send there
 
 hin|schleppen:
   language: de
@@ -1769,55 +1251,15 @@ hinab|blicken:
   translations:
     en: look down
 
-hinab|fallen/hinunter|fallen:
-  language: de
-  translations:
-    en: fall down
-
-hinab|lassen:
-  language: de
-  translations:
-    en: lower down (e.g. with a rope)
-
-hinunter|lassen:
-  language: de
-  translations:
-    en: lower down (e.g. with a rope)
-
 hinunter|spülen:
   language: de
   translations:
     en: wash down
 
-hinauf|gehen:
-  language: de
-  translations:
-    en: walk up, walk upstairs, go upwards
-
-hinauf|schauen:
-  language: de
-  translations:
-    en: look up etc.
-
-hinaus|bringen:
-  language: de
-  translations:
-    en: take out
-
 hinaus|ekeln:
   language: de
   translations:
     en: drive out in disgust
-
-hinaus|gehen:
-  language: de
-  translations:
-    en: go out
-
-auf etwas hinaus|laufen:
-  language: de
-  translations:
-    en: lead to something
 
 hinaus|ragen:
   language: de
@@ -1849,35 +1291,17 @@ hinaus|zögern:
   translations:
     en: draw out, delay
 
-hinein|drängen:
-  language: de
-  translations:
-    en: fall into
-
 hinein|dürfen:
   language: de
   translations:
     en: be allowed in
-
-hinein|fallen:
-  language: de
-  translations:
-    en: fall into
 
 hinein|fließen:
   language: de
   translations:
     en: flow into
 
-hinein|gehen:
-  language: de
-  translations:
-    en: enter
 
-hinein|reichen:
-  language: de
-  translations:
-    en: reach into
 
 hinein|reiten:
   language: de
@@ -1919,21 +1343,6 @@ hinterher|hinken:
   translations:
     en: limp along behind
 
-hinterher|kommen:
-  language: de
-  translations:
-    en: follow after
-
-hinterher|laufen:
-  language: de
-  translations:
-    en: run after
-
-hinterher|schicken:
-  language: de
-  translations:
-    en: [send after, send on]
-
 hinzu|fügen:
   language: de
   translations:
@@ -1949,25 +1358,10 @@ hinzu|gesellen:
   translations:
     en: join
 
-hinzu|kommen:
-  language: de
-  translations:
-    en: be added to
-
 hinzu|verdienen:
   language: de
   translations:
     en: earn (something) extra
-
-hinzu|ziehen:
-  language: de
-  translations:
-    en: consult
-
-jemanden hoch|bringen:
-  language: de
-  translations:
-    en: help someone up
 
 hoch|halten:
   language: de
@@ -1979,11 +1373,6 @@ hoch|krempeln:
   translations:
     en: roll up [a sleeve]
 
-hoch|legen:
-  language: de
-  translations:
-    en: support in a raised position
-
 hoch|rechnen:
   language: de
   translations:
@@ -1994,40 +1383,11 @@ hoch|schießen:
   translations:
     en: shoot upwards
 
-los|binden:
-  language: de
-  translations:
-    en: untie
-
-los|fahren:
-  language: de
-  translations:
-    en: drive off
-
-los|gehen:
-  language: de
-  translations:
-    en: commence
-
-los|kommen:
-  language: de
-  translations:
-    en: get away
-
 los|kriegen:
   language: de
   translations:
     en: get rid of
 
-los|lassen:
-  language: de
-  translations:
-    en: let go of
-
-los|legen:
-  language: de
-  translations:
-    en: get started  let it rip
 
 sich los|reißen:
   language: de
@@ -2044,65 +1404,15 @@ los|wollen:
   translations:
     en: want to be off
 
-mit|arbeiten:
-  language: de
-  translations:
-    en: collaborate, work along with
-
 mit|dürfen:
   language: de
   translations:
     en: be allowed to go along
 
-mit|fahren:
-  language: de
-  translations:
-    en: ride with
-
-etwas mit|geben:
-  language: de
-  translations:
-    en: give something [for the purpose of taking it along]
-
 mit|halten:
   language: de
   translations:
     en: keep up with
-
-mit|helfen:
-  language: de
-  translations:
-    en: help out
-
-mit|hören:
-  language: de
-  translations:
-    en: listen in, eavesdrop
-
-mit|kommen:
-  language: de
-  translations:
-    en: come along
-
-mit|machen:
-  language: de
-  translations:
-    en: participate
-
-mit|nehmen:
-  language: de
-  translations:
-    en: take along
-
-mit|reden:
-  language: de
-  translations:
-    en: [participate in the conversation, have a say]
-
-mit|schreiben:
-  language: de
-  translations:
-    en: take notes
 
 mit|singen:
   language: de
@@ -2128,11 +1438,6 @@ nach|ahmen:
   language: de
   translations:
     en: imitate
-
-nach|arbeiten:
-  language: de
-  translations:
-    en: do make-up work
 
 nach|bessern:
   language: de
@@ -2184,47 +1489,10 @@ nach|füllen:
   translations:
     en: [refill, top off]
 
-nach|geben:
-  language: de
-  translations:
-    en: [give way, give in]
-
-nach|gehen:
-  language: de
-  translations:
-    en: [follow after, look into (an issue), run slow (clock)]
-
 nach|haken:
   language: de
   translations:
     en: [dig deeper, ask further about]
-
-nach|holen:
-  language: de
-  translations:
-    en: [catch up on, make up for, fetch later]
-
-nach|kommen:
-  language: de
-  translations:
-    en: [come later]
-
-nach|lassen:
-  language: de
-  translations:
-    en: diminish, loosen
-
-nach|machen:
-  language: de
-  translations:
-    en: imitate, counterfeit
-
-nach|reichen:
-  language: de
-  translations:
-    en: hand in later
-
-
 
 nach|trauern:
   language: de
@@ -2341,11 +1609,6 @@ um|schalten:
   translations:
     en: change, switch (gears, channels)
 
-um|stimmen:
-  language: de
-  translations:
-    en: persuade [to change one's mind]
-
 um|schulen:
   language: de
   translations:
@@ -2376,15 +1639,7 @@ vor|beugen:
   translations:
     en: [prevent, bend forward]
 
-vor|drängen:
-  language: de
-  translations:
-    en: push forward
 
-jemandem vor|greifen:
-  language: de
-  translations:
-    en: jump in ahead of someone
 
 vor|herrschen:
   language: de
@@ -2417,10 +1672,6 @@ vorüber|eilen:
   translations:
     en: hurry past
 
-vorweg|schicken:
-  language: de
-  translations:
-    en: send off in anticipation
 
 weg|blasen:
   language: de
@@ -2457,10 +1708,6 @@ wieder|herstellen:
   translations:
     en: restore, reestablish
 
-wieder|holen:
-  language: de
-  translations:
-    en: repeat
 
 wieder|käuen:
   language: de
@@ -2487,10 +1734,7 @@ zurück|erobern:
   translations:
     en: recapture
 
-zurück|lehnen:
-  language: de
-  translations:
-    en: lean back
+
 
 zurück|schrecken:
   language: de

--- a/apps/db_management/src/data/germanverbs.yaml
+++ b/apps/db_management/src/data/germanverbs.yaml
@@ -2078,11 +2078,11 @@ nehmen:
       translations:
         en: arrest
     - particle: entgegen
-        translations:
-          en: [accept, receive]
+      translations:
+        en: [accept, receive]
     - particle: ab
-        translations:
-          en: [remove, take away]
+      translations:
+        en: [remove, take away]
 
 sterben:
   language: de
@@ -3591,4 +3591,3 @@ drücken:
     - particle: vor
       translations:
         en: move forward
-

--- a/apps/db_management/src/data/germanverbs.yaml
+++ b/apps/db_management/src/data/germanverbs.yaml
@@ -17,6 +17,10 @@ haben:
     - particle: vor
       translations:
         en: intend
+    - particle: an
+      language: de
+      translations:
+        en: [have on, wear]
 
 sein:
   auxiliary: true
@@ -41,6 +45,12 @@ sein:
     - particle: voraus
       translations:
         en: be in advance, be ahead
+    - particle: auf
+      translations:
+        en: be open, be up
+    - particle: dabei
+      translations:
+        en: be present at, take part in
 
 werden:
   auxiliary: true
@@ -60,6 +70,10 @@ werden:
     präteritum:
       ich: wurde
       es: wurde
+  variations:
+    - particle: etwas los
+      translations:
+        en: get rid of something
 
 können:
   language: de
@@ -107,6 +121,16 @@ wollen:
   stems:
     präsensSingular: i
   drop: true
+  variations:
+    - particle: hinaus
+      translations:
+        en: want to go out
+    - particle: hinein
+      translations:
+        en: want to go in
+    - particle: los
+      translations:
+        en: want to be off  
 
 sollen:
   language: de
@@ -129,6 +153,13 @@ dürfen:
     partizip: u
   drop: true
   weakEndings: true
+  variations:
+    - particle: hinein
+      translations:
+        en: be allowed in
+    - particle: mit
+      translations:
+        en: be allowed to go along
 
 mögen:
   language: de
@@ -188,7 +219,28 @@ lassen:
     - particle: nieder
       sich: true
       translations:
-        en: ensconce oneself      
+        en: ensconce oneself
+    - particle: nach
+      translations:
+        en: diminish, loosen
+    - particle: los
+      translations:
+        en: let go of
+    - particle: hinunter
+      translations:
+        en: lower down (e.g. with a rope)
+    - particle: da
+      translations:
+        en: leave there
+    - particle: ein
+      translations:
+        en: allow to enter
+    - particle: durch
+      translations:
+        en: allow through
+    - particle: hinab
+      translations:
+        en: lower down (e.g. with a rope)    
 
 gehen:
   language: de
@@ -232,6 +284,51 @@ gehen:
     - particle: nebenher
       translations:
         en: walk alongside
+    - particle: hinauf
+      translations:
+        en: walk up, walk upstairs, go upwards
+    - particle: hervor
+      translations:
+        en: emerge, lure out
+    - particle: heran
+      translations:
+        en: go up closer
+    - particle: heim
+      translations:
+        en: go/walk home
+    - particle: fehl
+      translations:
+        en: go wrong
+    - particle: entzwei
+      translations:
+        en: come apart
+    - particle: entlang
+      translations:
+        en: [go along, walk along]
+    - particle: ein
+      translations:
+        en: enter, sink in, shrink
+    - particle: durch
+      translations:
+        en: walk through
+    - particle: auseinander
+      translations:
+        en: part, disperse
+    - particle: aus
+      translations:
+        en: go out
+    - particle: nach
+      translations:
+        en: [follow after, look into (an issue), run slow (clock)]
+    - particle: los
+      translations:
+        en: commence
+    - particle: hinein
+      translations:
+        en: enter
+    - particle: hinaus
+      translations:
+        en: go out
 
 laufen:
   language: de
@@ -251,6 +348,21 @@ laufen:
     - particle: nebenher
       translations:
         en: [run alongside, proceed at the same time]
+    - particle: entlang
+      translations:
+        en: [go along, walk along]
+    - particle: hinterher
+      translations:
+        en: run after
+    - particle: herbei
+      translations:
+        en: to come running up
+    - particle: fort
+      translations:
+        en: run away
+    - particle: fest
+      translations:
+        en: run aground
 
 schreiben:
   language: de
@@ -262,6 +374,16 @@ schreiben:
     präteritum: ie
     k2präsens: ie
     partizip: ie
+  variations:
+    - particle: mit
+      translations:
+        en: take notes
+    - particle: auf
+      translations:
+        en: write down
+    - particle: ein
+      translations:
+        en: enroll
 
 folgen:
   language: de
@@ -269,6 +391,10 @@ folgen:
   translations:
     en: follow
   hilfsverb: sein
+  variations:
+    - particle: nach
+      translations:
+        en: succeed, follow
 
 greifen:
   language: de
@@ -284,6 +410,9 @@ greifen:
     - particle: zu
       translations:
         en: [take hold, help oneself (to something)]
+    - particle: an
+      translations:
+        en: attack
 
 pfeifen:
   language: de
@@ -295,6 +424,10 @@ pfeifen:
     präteritum: iff
     k2präsens: iff
     partizip: iff
+  variations:
+    - particle: an
+      translations:
+        en: whistle for play to start
 
 schreien:
   language: de
@@ -353,6 +486,15 @@ hängen:
     - particle: um
       translations:
         en: re-hang (curtains), drape around
+    - particle: herab
+      translations:
+        en: hang down
+    - particle: an
+      translations:
+        en: attach
+    - particle: heraus
+      translations:
+        en: hang out
 
 leiden:
   language: de
@@ -378,7 +520,33 @@ halten:
   variations:
     - particle: nieder
       translations:
-        en: oppress 
+        en: oppress
+    - particle: an
+      translations:
+        en: cause to stop
+    - particle: aus
+      translations:
+        en: endure, withstand
+    - particle: durch
+      translations:
+        en: withstand, endure
+    - particle: fest
+      translations:
+        en: hold on firmly
+    - particle: frei
+      translations:
+        en: keep clear (not block)
+    - particle: hin
+      translations:
+        en:
+          - hold out
+          - delay
+    - particle: hoch
+      translations:
+        en: hold up [in a raised position]
+    - particle: mit
+      translations:
+        en: keep up with
 
 schlafen:
   language: de
@@ -422,6 +590,9 @@ spielen:
     - particle: nach
       translations:
         en: play during time that has been added on (injury time in soccer)
+    - particle: mit
+      translations:
+        en: take part in the game
 
 machen:
   language: de
@@ -437,7 +608,28 @@ machen:
         en: close
     - particle: weiter
       translations:
-        en: carry on      
+        en: carry on
+    - particle: mit
+      translations:
+        en: participate
+    - particle: nach
+      translations:
+        en: imitate, counterfeit
+    - particle: an
+      translations:
+        en: [attach, make a pass at]
+    - particle: auf
+      translations:
+        en: open
+    - particle: fest
+      translations:
+        en: fasten firmly
+    - particle: gleich
+      translations:
+        en: make equal
+    - particle: aus
+      translations:
+        en: turn off, extinguish, make a difference, add up to
 
 fragen:
   language: de
@@ -484,10 +676,22 @@ reden:
   variations:
     - particle: weiter
       translations:
-        en: continue talking      
+        en: continue talking
     - particle: vorbei
       translations:
-        en: talk past    
+        en: talk past
+    - particle: ein
+      translations:
+        en: pursuade
+    - particle: dazwischen
+      translations:
+        en: interrupt
+    - particle: fort
+      translations:
+        en: continue talking
+    - particle: mit
+      translations:
+        en: [participate in the conversation, have a say]
 
 bedeuten:
   language: de
@@ -513,6 +717,15 @@ kaufen:
   infinitive: kaufen
   translations:
     en: buy
+  variations:
+    - particle: ein
+      translations:
+        en: shop
+    - particle: frei
+      translations:
+        en:
+          - ransom
+          - buy someone's freedom
 
 schmecken:
   language: de
@@ -536,6 +749,10 @@ wohnen:
   infinitive: wohnen
   translations:
     en: [live (somewhere), inhabit]
+  variations:
+    - particle: bei
+      translations:
+        en: be present at
 
 arbeiten:
   language: de
@@ -553,12 +770,41 @@ arbeiten:
     - particle: um
       translations:
         en: rework
+    - particle: auf
+      translations:
+        en: finish off, reuse
+    - particle: nach
+      translations:
+        en: do make-up work
+    - particle: mit
+      translations:
+        en: collaborate, work along with
+    - particle: hin
+      translations:
+        en: work towards
+    - particle: herauf
+      translations:
+        en: work one's way up
+    - particle: entgegen
+      translations:
+        en: work against
+    - particle: empor
+      sich: true
+      translations:
+        en: work one's way up
+    - particle: durch
+      translations:
+        en: work through
 
 brauchen:
   language: de
   infinitive: brauchen
   translations:
     en: need
+  variations:
+    - particle: auf
+      translations:
+        en: use up
 
 setzen:
   language: de
@@ -580,13 +826,47 @@ setzen:
         en: put before      
     - particle: um
       translations:
-        en: [transfer, transpose, implement, transact, transform]     
+        en: [transfer, transpose, implement, transact, transform]
+    - particle: bei
+      translations:
+        en: bury
+    - particle: entgegen
+      translations:
+        en: contrast
+    - particle: fort
+      translations:
+        en:
+          - continue
+          - carry on with
+          - resume
+    - particle: frei
+      translations:
+        en: release
+    - particle: gleich
+      translations:
+        en: equate
+    - particle: herab
+      translations:
+        en: reduce, disparage
+    - particle: hin
+      sich: true
+      translations:
+        en: sit down
+    - particle: hinzu
+      translations:
+        en:
+          - add
+          - append  
 
 suchen:
   language: de
   infinitive: suchen
   translations:
     en: search
+  variations:
+    - particle: heim
+      translations:
+        en: afflict
 
 versuchen:
   language: de
@@ -609,6 +889,15 @@ bauen:
     - particle: vor
       translations:
         en: make provision
+    - particle: aus
+      translations:
+        en: extend, improve, expand
+    - particle: auf
+      translations:
+        en: build up
+    - particle: an
+      translations:
+        en: [build on, add, cultivate (a crop)]
 
 tagen:
   language: de
@@ -621,6 +910,10 @@ deuten:
   infinitive: deuten
   translations:
     en: [construe, interpret]
+  variations:
+    - particle: hin
+      translations:
+        en: point to
 
 hören:
   language: de
@@ -641,6 +934,9 @@ hören:
       sich: true 
       translations:
         en: keep one's ears open
+    - particle: mit
+      translations:
+        en: listen in, eavesdrop
 
 fallen:
   language: de
@@ -666,6 +962,37 @@ fallen:
     - particle: um
       translations:
         en: [fall over, fall down]
+    - particle: hin
+      translations:
+        en: fall down
+    - particle: herunter
+      translations:
+        en: fall down
+    - particle: herein
+      translations:
+        en: fall into, be duped
+    - particle: herab
+      translations:
+        en: fall from
+    - particle: auseinander
+      translations:
+        en: fall apart
+    - particle: aus
+      translations:
+        en: fail, drop out, be canceled
+    - particle: auf
+      dative: true
+      translations:
+        en: stand out, be noticeable
+    - particle: hinein
+      translations:
+        en: fall into
+    - particle: hinab
+      translations:
+        en: fall down
+    - particle: hinunter
+      translations:
+        en: fall down
 
 zerfallen:
   language: de
@@ -694,6 +1021,10 @@ braten:
     duEs: ä
     präteritum: ie
     k2präsens: ie
+  variations:
+    - particle: durch
+      translations:
+        en: cook or roast all the way through
 
 raten:
   language: de
@@ -741,6 +1072,42 @@ fahren:
     - particle: nebenher
       translations:
         en: drive alongside
+    - particle: hin
+      translations:
+        en: go/drive there
+    - particle: herüber
+      translations:
+        en: drive over here
+    - particle: heraus
+      translations:
+        en: drive out of
+    - particle: her
+      translations:
+        en: [travel here, drive here]
+    - particle: heim
+      translations:
+        en: drive home
+    - particle: fort
+      translations:
+        en: continue
+    - particle: ein
+      translations:
+        en: drive in
+    - particle: durch
+      translations:
+        en: drive straight through
+    - particle: aus
+      translations:
+        en: go for a drive, take for a drive
+    - particle: an
+      translations:
+        en: [drive up, arrive (by car)]
+    - particle: mit
+      translations:
+        en: ride with
+    - particle: los
+      translations:
+        en: drive off
 
 graben:
   language: de
@@ -775,6 +1142,15 @@ schlagen:
     - particle: nieder
       translations:
         en: [knock down, suppress, make despondent]
+    - particle: auf
+      translations:
+        en: open [a book]
+    - particle: ein
+      translations:
+        en: hammer in, knock in
+    - particle: entzwei
+      translations:
+        en: smash into two pieces
 
 waschen:
   language: de
@@ -796,6 +1172,10 @@ wachsen:
   stems:
     duEs: ä
     präteritum: u
+  variations:
+    - particle: über etwas hinaus
+      translations:
+        en: grow beyond/outgrow something  
 
 tragen:
   language: de
@@ -810,6 +1190,18 @@ tragen:
     - particle: vor
       translations:
         en: perform, present (a speech, song, etc.)
+    - particle: bei
+      translations:
+        en: contribute [to]
+    - particle: her
+      translations:
+        en: carry (to) here (in this direction)
+    - particle: herauf
+      translations:
+        en: carry up here
+    - particle: hin
+      translations:
+        en: carry there
 
 laden:
   language: de
@@ -827,6 +1219,9 @@ laden:
     - particle: um
       translations:
         en: transfer (a load)
+    - particle: ein
+      translations:
+        en: invite
 
 #-------------------------------------------------------------------------------
 # BARREL ones from smarter german
@@ -840,6 +1235,18 @@ liegen:
   stems:
     präteritum: a
     partizip: e
+  variations:
+    - particle: bei
+      translations:
+        en: be enclosed [along with]
+    - particle: das würde mir fern
+      translations:
+        en: that would be the last thing I would do
+    - particle: gegenüber
+      translations:
+        en:
+          - face
+          - be across from
 
 bitten:
   language: de
@@ -850,6 +1257,13 @@ bitten:
   stems:
     präteritum: at
     partizip: et
+  variations:
+    - particle: heraus
+      translations:
+        en: ask (someone) to come outside
+    - particle: herein
+      translations:
+        en: invite in
 
 sitzen:
   language: de
@@ -860,6 +1274,18 @@ sitzen:
   stems:
     präteritum: aß
     partizip: ess
+  variations:
+    - particle: dabei
+      translations:
+        en: sit/stand there, stick with
+    - particle: fest
+      translations:
+        en: be stuck
+    - particle: gegenüber
+      translations:
+        en:
+          - sit facing
+          - sit across from  
 
 geben:
   language: de
@@ -888,7 +1314,22 @@ geben:
         en: pretend 
     - particle: statt
       translations:
-        en: [accede to, grant, allow] 
+        en: [accede to, grant, allow]
+    - particle: nach
+      translations:
+        en: [give way, give in]
+    - particle: hin
+      translations:
+        en: devote, sacrifice
+    - particle: heraus
+      translations:
+        en: [hand over, hand out]
+    - particle: frei
+      translations:
+        en: [release (a prisoner), allow (a currency) to float]
+    - particle: auf
+      translations:
+        en: give up
 
 lesen:
   language: de
@@ -909,6 +1350,19 @@ treten:
   stems:
     duEs: itt
     präteritum: a
+  variations:
+    - particle: bei
+      translations:
+        en: join
+    - particle: ein
+      translations:
+        en: enter
+    - particle: entgegen
+      translations:
+        en: confront
+    - particle: hervor
+      translations:
+        en: emerge, step forth  
 
 essen:
   language: de
@@ -920,6 +1374,10 @@ essen:
     duEs: i
     präteritum: aß
     partizip: gess
+  variations:
+    - particle: auf
+      translations:
+        en: eat up  
 
 sehen:
   language: de
@@ -953,6 +1411,9 @@ sehen:
     - particle: nach
       translations:
         en: [look up, check up]
+    - particle: fern
+      translations:
+        en: watch television
 
 geschehen:
   language: de
@@ -982,6 +1443,9 @@ fliegen:
     - particle: vorüber
       translations:
         en: fly by
+    - particle: auf
+      translations:
+        en: fly up
 
 fliehen:
   language: de
@@ -1007,7 +1471,13 @@ fließen:
   variations:
     - particle: zu
       translations:
-        en: flow toward    
+        en: flow toward
+    - particle: herab
+      translations:
+        en: flow down
+    - particle: hinein
+      translations:
+        en: flow into  
 
 frieren:
   language: de
@@ -1019,6 +1489,10 @@ frieren:
   stems:
     präteritum: o
     partizip: o
+  variations:
+    - particle: fest
+      translations:
+        en: ice over
 
 biegen:
   language: de
@@ -1029,6 +1503,13 @@ biegen:
   stems:
     präteritum: o
     partizip: o
+  variations:
+    - particle: ein
+      translations:
+        en: turn in
+    - particle: hin
+      translations:
+        en: arrange
 
 bieten:
   language: de
@@ -1075,6 +1556,27 @@ ziehen:
     - particle: um
       translations:
         en: move (to change address)
+    - particle: hinzu
+      translations:
+        en: consult
+    - particle: ab
+      translations:
+        en: deduct, withdraw
+    - particle: an
+      translations:
+        en: attract, put on
+    - particle: heraus
+      translations:
+        en: pull out
+    - particle: herauf
+      translations:
+        en: [pull up, approach]
+    - particle: auf
+      translations:
+        en: wind up, raise [children]
+    - particle: durch
+      translations:
+        en: pull through [an opening]).
 
 wiegen:
   language: de
@@ -1111,6 +1613,10 @@ schieben:
   stems:
     präteritum: o
     partizip: o
+  variations:
+    - particle: hinaus
+      translations:
+        en: postpone
 
 schießen:
   language: de
@@ -1127,7 +1633,16 @@ schießen:
         en: miss (the target)      
     - particle: nieder
       translations:
-        en: gun down      
+        en: gun down
+    - particle: an
+      translations:
+        en: shoot at and wound
+    - particle: empor
+      translations:
+        en: shoot up [grow suddenly]
+    - particle: hoch
+      translations:
+        en: shoot upwards     
 
 schließen:
   language: de
@@ -1138,6 +1653,13 @@ schließen:
   stems:
     präteritum: oss
     partizip: oss
+  variations:
+    - particle: auf
+      translations:
+        en: unlock, open up
+    - particle: aus
+      translations:
+        en: exclude, lock out    
 
 heben:
   language: de
@@ -1148,6 +1670,13 @@ heben:
   stems:
     präteritum: o
     partizip: o
+  variations:
+    - particle: empor
+      translations:
+        en: lift up
+    - particle: hervor
+      translations:
+        en: emphasize
 
 saufen:
   language: de
@@ -1219,10 +1748,22 @@ bleiben:
   variations:
     - particle: zurück
       translations:
-        en: stay behind      
+        en: stay behind
     - particle: weg
       translations:
-        en: stay away      
+        en: stay away
+    - particel: da
+      translations:
+        en: stay there
+    - particel: dabei
+      translations:
+        en: stay there, stick with
+    - particel: aus
+      translations:
+        en: stay away, fail to show up
+    - particel: gleich
+      translations:
+        en: stay the same
 
 reiben:
   language: de
@@ -1257,6 +1798,10 @@ reiten:
     präteritum: itt
     k2präsens: itt
     partizip: itt
+  variations:
+    - particle: hinein
+      translations:
+        en: ride in (on horseback)
 
 reißen:
   language: de
@@ -1272,6 +1817,17 @@ reißen:
     - particle: nieder
       translations:
         en: tear down
+    - particle: entzwei
+      translations:
+        en: rip in two
+    - particle: hin
+      translations:
+        en:
+          - delight
+          - fascinate
+    - particle: sich los
+      translations:
+        en: break free of
 
 beißen:
   language: de
@@ -1286,7 +1842,13 @@ beißen:
   variations:
     - particle: zusammen
       translations:
-        en: bite together      
+        en: bite together
+    - particle: an
+      translations:
+        en: take a bite of
+    - particle: fest
+      translations:
+        en: bite into firmly    
 
 scheißen:
   language: de
@@ -1309,6 +1871,10 @@ leihen:
     präteritum: ie
     k2präsens: ie
     partizip: ie
+  variations:
+    - particle: aus
+      translations:
+        en: lend
 
 scheinen:
   language: de
@@ -1353,6 +1919,21 @@ steigen:
     - particle: um
       translations:
         en: transfer (change buses, trains, planes)
+    - particle: aus
+      translations:
+        en: get out of [a car, train]
+    - particle: ein
+      translations:
+        en: enter [a vehicle]
+    - particle: empor
+      translations:
+        en: climb up
+    - particle: herab
+      translations:
+        en: climb down, descend
+    - particle: herunter
+      translations:
+        en: climb down
 
 verzeihen:
   language: de
@@ -1408,7 +1989,67 @@ kommen:
         en: [happen, seem]      
     - particle: um
       translations:
-        en: get killed      
+        en: get killed
+    - particle: heim
+      translations:
+        en: come home
+    - particle: gleich
+      translations:
+        en: [equal, be tantamount to]
+    - particle: frei
+      translations:
+        en: [escape, get away]
+    - particle: entgegen
+      translations:
+        en: [approach, accommodate, meet halfway]
+    - particle: dahinter
+      translations:
+        en: find out
+    - particle: bei
+      translations:
+        en: get hold of, deal with
+    - particle: auf
+      translations:
+        en: arise, spring for [costs]
+    - particle: an
+      translations:
+        en: arrive
+    - particle: ab
+      translations:
+        en: get away
+    - particle: los
+      translations:
+        en: get away
+    - particle: hinzu
+      translations:
+        en: be added to
+    - particle: hinterher
+      translations:
+        en: follow after
+    - particle: hin
+      translations:
+        en: get there
+    - particle: herunter
+      translations:
+        en: come down (go to the dogs)
+    - particle: heran
+      translations:
+        en: draw near
+    - particle: her
+      translations:
+        en: [come here, come from]
+    - particle: herein
+      translations:
+        en: come in
+    - particle: herüber
+      translations:
+        en: come over here
+    - particle: mit
+      translations:
+        en: come along
+    - particle: nach
+      translations:
+        en: [come later]
 
 nehmen:
   language: de
@@ -1426,7 +2067,22 @@ nehmen:
         en: [increase, gain weight]
     - particle: vorweg
       translations:
-        en: [anticipate, pre-empt, forestall]      
+        en: [anticipate, pre-empt, forestall]
+    - particle: mit
+      translations:
+        en: take along
+    - particle: hin
+      translations:
+        en: accept, put up with
+    - particle: est
+      translations:
+        en: arrest
+    - particle: entgegen
+        translations:
+          en: [accept, receive]
+    - particle: ab
+        translations:
+          en: [remove, take away]
 
 sterben:
   language: de
@@ -1458,6 +2114,18 @@ brechen:
     - particle: ein
       translations:
         en: [crack, burgle, collapse, break in, cave in]
+    - particle: auf
+      translations:
+        en: break open
+    - particle: auseinander
+      translations:
+        en: break up, break apart
+    - particle: durch
+      translations:
+        en: break through
+    - particle: entzwei
+      translations:
+        en: break in two
 
 helfen:
   language: de
@@ -1469,6 +2137,16 @@ helfen:
     duEs: i
     präteritum: a
     partizip: o
+  variations:
+    - particle: aus
+      translations:
+        en: help out
+    - particle: mit
+      translations:
+        en: help out
+    - particle: jemandem über etwas hinweg
+      translations:
+        en: help someone to get over something
 
 sprechen:
   language: de
@@ -1487,6 +2165,14 @@ sprechen:
     - particle: nach
       translations:
         en: repeat after
+    - particle: an
+      translations:
+        en:
+          - speak to
+          - initiate a conversation with
+    - particle: durch
+      translations:
+        en: talk through, talk over, talk out, argue something out
 
 
 stechen:
@@ -1547,6 +2233,12 @@ werfen:
     - particle: nieder
       translations:
         en: [overcome, defeat]
+    - particle: ein
+      translations:
+        en: throw in, drop [a coin or letter]
+    - particle: hinaus
+      translations:
+        en: throw out
 
 schwimmen:
   language: de
@@ -1595,7 +2287,16 @@ binden:
   variations:
     - particle: zu
       translations:
-        en: tie, tie up   
+        en: tie, tie up
+    - particle: los
+      translations:
+        en: untie
+    - particle: an
+      translations:
+        en: attach
+    - particle: auf
+      translations:
+        en: untie, undo
 
 finden:
   language: de
@@ -1614,6 +2315,15 @@ finden:
     - particle: statt
       translations:
         en: take place
+    - particle: heim
+      translations:
+        en: find one's way home
+    - particle: sich durch
+      translations:
+        en: find one's way through
+    - particle: hin
+      translations:
+        en: find one's way to
 
 trinken:
   language: de
@@ -1645,6 +2355,10 @@ sinken:
   stems:
     präteritum: a
     partizip: u
+  variations:
+    - particle: herab
+      translations:
+        en: sink down, descend
 
 springen:
   language: de
@@ -1656,6 +2370,10 @@ springen:
   stems:
     präteritum: a
     partizip: u
+  variations:
+    - particle: ein
+      translations:
+        en: jump in [to help out]
 
 singen:
   language: de
@@ -1670,6 +2388,9 @@ singen:
     - particle: vor
       translations:
         en: sing (in front of people)
+    - particle: mit
+      translations:
+        en: sing along
 
 zwingen:
   language: de
@@ -1680,6 +2401,10 @@ zwingen:
   stems:
     präteritum: a
     partizip: u
+  variations:
+    - particle: auf
+      translations:
+        en: force upon
 
 danken:
   language: de
@@ -1711,7 +2436,10 @@ brennen:
         en: burn down    
     - particle: nieder
       translations:
-        en: burn down    
+        en: burn down
+    - particle: aus
+      translations:
+        en: burn out  
 
 kennen:
   language: de
@@ -1770,6 +2498,33 @@ bringen:
     - particle: um
       translations:
         en: kill
+    - particle: hinaus
+      translations:
+        en: take out
+    - particle: hin
+      translations:
+        en: take there
+    - particle: herein
+      translations:
+        en: bring in
+    - particle: herbei
+      translations:
+        en: bring over
+    - particle: heraus
+      translations:
+        en: [bring out, publish, launch, make known]
+    - particle: heran
+      translations:
+        en: [bring toward, bring up to (a certain point)]
+    - particle: bei
+      translations:
+        en: teach
+    - particle: an
+      translations:
+        en: [fasten, install]
+    - particle: fort
+      translations:
+        en: take away (for repair)
 
 stehen:
   language: de
@@ -1780,6 +2535,15 @@ stehen:
   stems:
     präteritum: and
     partizip: and
+  variations:
+    - particle: dabei
+      translations:
+        en: sit/stand there, stick with
+    - particle: gegenüber
+      translations:
+        en:
+          - stand facing
+          - be confronted with
 
 tun:
   language: de
@@ -1790,6 +2554,10 @@ tun:
   stems:
     präteritum: at
     partizip: a
+  variations:
+    - particle: sich hervor
+      translations:
+        en: excel
 
 rennen:
   language: de
@@ -1856,6 +2624,21 @@ bekommen:
     - particle: wieder
       translations:
         en: get back
+    - particle: auseinander
+      translations:
+        en: manage, get apart
+    - particle: frei
+      translations:
+        en:
+          - get time off
+    - particle: herunter
+      translations:
+        en:
+          - be able to eat
+          - manage to get down
+    - particle: hin
+      translations:
+        en: wangle, manage to do
 
 
 #-------------------------------------------------------------------------------
@@ -1892,6 +2675,10 @@ ein|schlafen:
   translations:
     en: fall asleep
   hilfsverb: sein
+  variations:
+    - particle: sich aus
+      translations:
+        en: get a good sleep
 
 er|frieren:
   language: de
@@ -1921,7 +2708,13 @@ bilden:
   infinitive: bilden
   translations:
     en: build
-
+  variations:
+  - particle: fort
+    translations:
+      en: continue (one's) education
+  - particle: aus
+    translations:
+      en: train
 
 
 entsprechen:
@@ -1996,7 +2789,10 @@ erzählen:
   variations:
     - particle: weiter
       translations:
-        en: tell further, continue a narration      
+        en: tell further, continue a narration
+    - particle: nach
+      translations:
+        en: retell
 
 führen:
   language: de
@@ -2019,6 +2815,30 @@ führen:
     - particle: vor
       translations:
         en: [bring forward, perform]
+    - particle: aus
+      translations:
+        en: take for a walk, carry out [work], put into practice
+    - particle: durch
+      translations:
+        en: implement, carry out [a task]
+    - particle: her
+      translations:
+        en:
+          - bring here
+          - lead here
+    - particle: heran
+      translations:
+        en:
+          - bring up (to a place)
+          - lead here
+    - particle: herauf
+      translations:
+        en:
+          - bring up here
+          - lead up here
+    - particle: hin
+      translations:
+        en: lead to
 
 interessieren:
   language: de
@@ -2033,6 +2853,10 @@ studieren:
   translations:
     en: study
   partizip: studiert
+  variations:
+    - particle: ein
+      translations:
+        en: rehearse
 
 legen:
   language: de
@@ -2045,7 +2869,22 @@ legen:
         en: lay out in readiness
     - particle: vor
       translations:
-        en: present 
+        en: present
+    - particle: hin
+      translations:
+        en: lay down
+    - particle: frei
+      translations:
+        en: uncover
+    - particle: fest
+      translations:
+        en: establish
+    - particle: los
+      translations:
+        en: get started  let it rip
+    - particle: hoch
+      translations:
+        en: support in a raised position
 
 meinen:
   language: de
@@ -2058,6 +2897,13 @@ schaffen:
   infinitive: schaffen
   translations:
     en: [create, accomplish]
+  variations:
+    - particle: ab
+      translations:
+        en: do away with
+    - particle: herbei
+      translations:
+        en: get
 
 scheiben:
   language: de
@@ -2086,6 +2932,19 @@ stellen:
     - particle: nach
       translations:
         en: readjust
+    - particle: entegen
+      sich: true
+      translations:
+        en: oppose
+    - particle: gegenüber
+      translations:
+        en:
+          - confront
+          - compare
+    - particle: heraus
+      sich: true
+      translations:
+        en: turn out (to be)
 
 vergehen:
   language: de
@@ -2103,6 +2962,10 @@ gleichen:
     präteritum: i
     k2präsens: i
     partizip: i
+  variations:
+    - particle: aus
+      translations:
+        en: even out 
 
 vergleichen:
   language: de
@@ -2115,8 +2978,10 @@ zeigen:
   infinitive: zeigen
   translations:
     en: exhibit, feature
-
-
+  variations:
+    - particle: an
+      translations:
+        en: report to the authorities, show
 
 verstehen:
   language: de
@@ -2156,12 +3021,20 @@ entwickeln:
     - particle: weiter
       translations:
         en: develop further
+    - particle: fort
+      sich: true
+      translations:
+        en: continue to develop
 
 handeln:
   language: de
   infinitive: handeln
   translations:
     en: [deal, negotiate]
+  variations:
+    - particle: herunter
+      translations:
+        en: bargain down
 
 erinnern:
   language: de
@@ -2188,6 +3061,10 @@ packen:
   infinitive: packen
   translations:
     en: pack
+  variations:
+  - particle: an
+    translations:
+      en: take hold of 
 
 versprechen:
   language: de
@@ -2232,17 +3109,21 @@ planen:
   translations:
     en: plan
 
-ein|atmen:
-  language: de
-  infinitive: ein|atmen
-  translations:
-    en: breathe in, inhale
-
 atmen:
   language: de
   infinitive: atmen
   translations:
     en: breathe
+  variations:
+    - particle: durch    
+      translations:
+        en: breathe deeply
+    - particle: auf
+      translations:
+        en: breathe a sigh of relief
+    - particle: ein
+      translations:
+        en: breathe in, inhale
 
 verheimlichen:
   language: de
@@ -2262,12 +3143,22 @@ drehen:
     - particle: um
       translations:
         en: turn around
+    - particle: auf
+      translations:
+        en: unscrew, turn up, wind up
+    - particle: durch
+      translations:
+        en: put through a grinder
 
 tauchen:
   language: de
   infinitive: tauchen
   translations:
     en: [dive, plunge]
+  variations:
+    - particle: ein
+      translations:
+        en: immerse, dive in
 
 auf|tauchen:
   language: de
@@ -2276,11 +3167,26 @@ auf|tauchen:
     en: [appear, crop up, come to light]
   hilfsverb: sein
 
-ein|richten:
+richten:
   language: de
-  infinitive: ein|richten
+  infinitive: richten
   translations:
-    en: [establish, furnish, organize]
+    en: target
+  variations:
+    - particle: ein
+      translations:
+        en: [establish, furnish, organize]
+    - particle: auf
+      translations:
+        en: erect
+    - particle: aus
+      translations:
+        en: pass on [a message]
+    - particle: hin
+      translations:
+        en:
+          - execute
+          - put to death
 
 sammeln:
   language: de
@@ -2309,6 +3215,13 @@ bestellen:
   infinitive: bestellen
   translations:
     en: [order, request, comission, book]
+  variations:
+    - particle: her
+      translations:
+        en: summon
+    - particle: nach
+      translations:
+        en: order more (of something)
 
 versetzen:
   language: de
@@ -2363,7 +3276,13 @@ fassen:
         en: grab at      
     - particle: um
       translations:
-        en: [grasp, include, embrace]    
+        en: [grasp, include, embrace]
+    - particle: an
+      translations:
+        en: take hold of
+    - particle: auf
+      translations:
+        en: grasp, undertsand
 
 wackeln:
   language: de
@@ -2384,7 +3303,16 @@ schauen:
     - particle: nach
       sich: true
       translations:
-        en: [look up, check up]    
+        en: [look up, check up]
+    - particle: herüber
+      translations:
+        en: look over here
+    - particle: an
+      translations:
+        en: look at
+    - particle: hinauf
+      translations:
+        en: look up etc.  
 
 begreifen:
   language: de
@@ -2407,6 +3335,13 @@ rufen:
   stems:
     präteritum: ie
     k2präsens: ie
+  variations:
+    - particle: herbei
+      translations:
+        en: call over
+    - particle: hervor
+      translations:
+        en: call to come out  
 
 an|rufen:
   language: de
@@ -2483,7 +3418,10 @@ stecken:
   variations:
     - particle: weg
       translations:
-        en: [put away, withstand (a blow)]    
+        en: [put away, withstand (a blow)]
+    - particle: hervor
+      translations:
+        en: stick out  
 
 #-------------------------------------------------------------------------------
 
@@ -2498,6 +3436,20 @@ bewegen:
   infinitive: bewegen
   translations:
     en: move
+  variations:
+    - particle: fort
+      sich: true
+      translations:
+        en:
+          - move along
+          - move on
+    - particle: hin
+      translations:
+        en: move toward
+    - particle: hin
+      sich: true
+      translations:
+        en: move upwards
 
 verwenden:
   language: de
@@ -2529,6 +3481,9 @@ weichen:
       dative: true
       translations:
         en: evade
+    - particle: auf
+      translations:
+        en: soften up
 
 
 befehlen:
@@ -2594,6 +3549,9 @@ passen:
     - particle: zusammen
       translations:
         en: be suited for each other
+    - particle: auf
+      translations:
+        en: look, watch out
 
 weisen: 
   language: de

--- a/apps/db_management/src/data/germanverbs.yaml
+++ b/apps/db_management/src/data/germanverbs.yaml
@@ -13,6 +13,10 @@ haben:
     duEs: ha
     präteritum: t
     partizip: b
+  variations:
+    - particle: vor
+      translations:
+        en: intend
 
 sein:
   auxiliary: true
@@ -33,6 +37,10 @@ sein:
       es: ist
       wir: sind
       ihr: seid
+  variations:
+    - particle: voraus
+      translations:
+        en: be in advance, be ahead
 
 werden:
   auxiliary: true
@@ -65,6 +73,10 @@ können:
     präsensSingular: a
     präteritum: o
   drop: true
+  variations:
+    - particle: weg
+      translations:
+        en: [be able to get away, be able to leave]
 
 müssen:
   language: de
@@ -78,6 +90,13 @@ müssen:
     präsensSingular: u
   strong: true
   drop: true
+  variations:
+    - particle: zurück
+      translations:
+        en: go back, return
+    - particle: weg
+      translations:
+        en: have to leave    
 
 wollen:
   language: de
@@ -156,6 +175,20 @@ lassen:
     duEs: ä
     präteritum: ieß
     k2präsens: ieß
+  variations:
+    - particle: zu
+      translations:
+        en: authorize      
+    - particle: vorbei
+      translations:
+        en: let by      
+    - particle: nieder
+      translations:
+        en: lower      
+    - particle: nieder
+      sich: true
+      translations:
+        en: ensconce oneself      
 
 gehen:
   language: de
@@ -168,6 +201,37 @@ gehen:
     präteritum: ing
     k2präsens: ing
     partizip: ang
+  variations:
+    - particle: zurück
+      translations:
+        en: have to go back
+    - particle: auf
+      translations:
+        en: [rise, realise, pan out, open]
+    - particle: weiter
+      translations:
+        en: move along
+    - particle: weg
+      translations:
+        en: go away
+    - particle: vorüber
+      translations:
+        en: go by
+    - particle: vorbei
+      translations:
+        en: walk past
+    - particle: voraus
+      translations:
+        en: go on ahead
+    - particle: vor
+      translations:
+        en: [proceed, go first]
+    - particle: nieder
+      translations:
+        en: [drop down, go down, land]
+    - particle: nebenher
+      translations:
+        en: walk alongside
 
 laufen:
   language: de
@@ -180,6 +244,13 @@ laufen:
     duEs: äu
     präteritum: ie
     k2präsens: ie
+  variations:
+    - particle: weg
+      translations:
+        en: run away
+    - particle: nebenher
+      translations:
+        en: [run alongside, proceed at the same time]
 
 schreiben:
   language: de
@@ -209,6 +280,10 @@ greifen:
     präteritum: iff
     k2präsens: iff
     partizip: iff
+  variations:
+    - particle: zu
+      translations:
+        en: [take hold, help oneself (to something)]
 
 pfeifen:
   language: de
@@ -274,6 +349,10 @@ hängen:
     präteritum: i
     k2präsens: i
     partizip: a
+  variations:
+    - particle: um
+      translations:
+        en: re-hang (curtains), drape around
 
 leiden:
   language: de
@@ -296,6 +375,10 @@ halten:
     duEs: ä
     präteritum: ie
     k2präsens: ie
+  variations:
+    - particle: nieder
+      translations:
+        en: oppress 
 
 schlafen:
   language: de
@@ -313,24 +396,59 @@ sagen:
   infinitive: sagen
   translations:
     en: say
+  variations:
+    - particle: aus
+      translations:
+        en: [state, testify]
+    - particle: weiter
+      translations:
+        en: pass (the word) on
+    - particle: vorweg
+      translations:
+        en: say in anticipation
+    - particle: voraus
+      translations:
+        en: predict
 
 spielen:
   language: de
   infinitive: spielen
   translations:
     en: play
+  variations:
+    - particle: vor
+      translations:
+        en: play (music in front of people)
+    - particle: nach
+      translations:
+        en: play during time that has been added on (injury time in soccer)
 
 machen:
   language: de
   infinitive: machen
   translations:
     en: make
+  variations:
+    - particle: zurecht
+      translations:
+        en: get (something) ready
+    - paricle: zu
+      translations:
+        en: close
+    - particle: weiter
+      translations:
+        en: carry on      
 
 fragen:
   language: de
   infinitive: fragen
   translations:
     en: ask
+  variations:
+    - particle: um
+      sich: true
+      translations:
+        en: ask around
 
 glauben:
   language: de
@@ -343,18 +461,33 @@ leben:
   infinitive: leben
   translations:
     en: live
+  variations:
+    - particle: weiter
+      translations:
+        en: continue living
 
 lernen:
   language: de
   infinitive: lernen
   translations:
     en: learn
+  variations:
+    - particle: um
+      translations:
+        en: learn to think differently    
 
 reden:
   language: de
   infinitive: reden
   translations:
     en: speak
+  variations:
+    - particle: weiter
+      translations:
+        en: continue talking      
+    - particle: vorbei
+      translations:
+        en: talk past    
 
 bedeuten:
   language: de
@@ -367,6 +500,13 @@ gehören:
   infinitive: gehören
   translations:
     en: belong
+  variations:
+    - particle: zusammen
+      translations:
+        en: belong together
+    - particle: zu
+      translations:
+        en: belong to      
 
 kaufen:
   language: de
@@ -385,6 +525,11 @@ warten:
   infinitive: warten
   translations:
     en: wait
+  variations:
+    - particle: ab
+      translations:
+        en: bide
+
 
 wohnen:
   language: de
@@ -397,6 +542,17 @@ arbeiten:
   infinitive: arbeiten
   translations:
     en: work
+  variations:
+    - particle: zusammen
+      translations:
+        en: work together
+    - particle: vor
+      sich: true
+      translations:
+        en: work one's way forward
+    - particle: um
+      translations:
+        en: rework
 
 brauchen:
   language: de
@@ -409,6 +565,22 @@ setzen:
   infinitive: setzen
   translations:
     en: [put, set]
+  variations:
+    - particle: zusammen
+      translations:
+        en: seat/put together
+    - particle: zurück
+      translations:
+        en: reverse, put back      
+    - particle: voraus
+      translations:
+        en: assume      
+    - particle: vor
+      translations:
+        en: put before      
+    - particle: um
+      translations:
+        en: [transfer, transpose, implement, transact, transform]     
 
 suchen:
   language: de
@@ -427,6 +599,16 @@ bauen:
   infinitive: bauen
   translations:
     en: build
+  variations:
+    - particle: zusammen
+      translations:
+        en: assemble
+    - particle: zu
+      translations:
+        en: block off
+    - particle: vor
+      translations:
+        en: make provision
 
 tagen:
   language: de
@@ -445,6 +627,20 @@ hören:
   infinitive: hören
   translations:
     en: [hear, listen]
+  variations:
+    - particle: zu
+      translations:
+        en: listen
+    - particle: ab
+      translations:
+        en: wiretap
+    - particle: auf
+      translations:
+        en: [stop, end]
+    - particle: um
+      sich: true 
+      translations:
+        en: keep one's ears open
 
 fallen:
   language: de
@@ -457,6 +653,19 @@ fallen:
     duEs: ä
     präteritum: iel
     k2präsens: iel
+  variations:
+    - particle: runter
+      translations:
+        en: [go flying, tip over the edge]
+    - particle: vor
+      translations:
+        en: happen
+    - particle: ein
+      translations:
+        en: [collapse, shrink, dip, to occur to]
+    - particle: um
+      translations:
+        en: [fall over, fall down]
 
 zerfallen:
   language: de
@@ -510,6 +719,28 @@ fahren:
   stems:
     duEs: ä
     präteritum: u
+  variations:
+    - particle: ab
+      translations:
+        en: [drive off,  depart (by car)]
+    - particle: zu
+      translations:
+        en: [drive towards, ride towards]
+    - particle: weg
+      translations:
+        en: drive off
+    - particle: vorüber
+      translations:
+        en: drive by
+    - particle: vorbei
+      translations:
+        en: drive past
+    - particle: vor
+      translations:
+        en: [drive on ahead, drive up in front (of a building)]
+    - particle: nebenher
+      translations:
+        en: drive alongside
 
 graben:
   language: de
@@ -520,6 +751,10 @@ graben:
   stems:
     duEs: ä
     präteritum: u
+  variations:
+    - particle: um
+      translations:
+        en: dig over to turn over (dirt)      
 
 schlagen:
   language: de
@@ -530,6 +765,16 @@ schlagen:
   stems:
     duEs: ä
     präteritum: u
+  variations:
+    - particle: zurück
+      translations:
+        en: hit back, strike back
+    - particle: vor
+      translations:
+        en: propose, suggest
+    - particle: nieder
+      translations:
+        en: [knock down, suppress, make despondent]
 
 waschen:
   language: de
@@ -561,6 +806,10 @@ tragen:
   stems:
     duEs: ä
     präteritum: u
+  variations:
+    - particle: vor
+      translations:
+        en: perform, present (a speech, song, etc.)
 
 laden:
   language: de
@@ -571,6 +820,13 @@ laden:
   stems:
     duEs: ä
     präteritum: u
+  variations:
+    - particle: vor
+      translations:
+        en: summon
+    - particle: um
+      translations:
+        en: transfer (a load)
 
 #-------------------------------------------------------------------------------
 # BARREL ones from smarter german
@@ -614,6 +870,25 @@ geben:
   stems:
     duEs: i
     präteritum: a
+  variations:
+    - particle: zurück
+      translations:
+        en: give back, return   
+    - particle: zu
+      translations:
+        en: admit to, confess
+    - particle: wieder
+      translations:
+        en: give back, repeat
+    - particle: weg
+      translations:
+        en: give away
+    - particle: vor
+      translations:
+        en: pretend 
+    - particle: statt
+      translations:
+        en: [accede to, grant, allow] 
 
 lesen:
   language: de
@@ -655,6 +930,29 @@ sehen:
   stems:
     duEs: ie
     präteritum: a
+  variations:
+    - particle: wieder
+      translations:
+        en: see again
+    - particle: weg
+      translations:
+        en: look away
+    - particle: voraus
+      translations:
+        en: foresee  
+    - particle: an
+      translations:
+        en: [inspect, view, look at, regard]
+    - particle: um
+      sich: true 
+      translations:
+        en: look around
+    - particle: aus
+      translations:
+        en: appear
+    - particle: nach
+      translations:
+        en: [look up, check up]
 
 geschehen:
   language: de
@@ -680,6 +978,10 @@ fliegen:
   stems:
     präteritum: o
     partizip: o
+  variations:
+    - particle: vorüber
+      translations:
+        en: fly by
 
 fliehen:
   language: de
@@ -702,6 +1004,10 @@ fließen:
   stems:
     präteritum: oss
     partizip: oss
+  variations:
+    - particle: zu
+      translations:
+        en: flow toward    
 
 frieren:
   language: de
@@ -743,6 +1049,32 @@ ziehen:
   stems:
     präteritum: og
     partizip: og
+  variations:
+    - particle: ziehen
+      translations:
+        en: pull together
+    - particle: zu
+      translations:
+        en: pull shut
+    - particle: weiter
+      translations:
+        en: move along
+    - particle: weg
+      translations:
+        en: [move away, pull away]      
+    - particle: vorüber
+      translations:
+        en: pass by      
+    - particle: vor
+      translations:
+        en: [prefer, pull forward,  draw (a curtain)]
+    - particle: um
+      sich: true
+      translations:
+        en: change clothes
+    - particle: um
+      translations:
+        en: move (to change address)
 
 wiegen:
   language: de
@@ -789,6 +1121,13 @@ schießen:
   stems:
     präteritum: oss
     partizip: oss
+  variations:
+    - particle: vorbei
+      translations:
+        en: miss (the target)      
+    - particle: nieder
+      translations:
+        en: gun down      
 
 schließen:
   language: de
@@ -877,6 +1216,13 @@ bleiben:
     präteritum: ie
     k2präsens: ie
     partizip: ie
+  variations:
+    - particle: zurück
+      translations:
+        en: stay behind      
+    - particle: weg
+      translations:
+        en: stay away      
 
 reiben:
   language: de
@@ -922,6 +1268,10 @@ reißen:
     präteritum: iss
     k2präsens: iss
     partizip: iss
+  variations:
+    - particle: nieder
+      translations:
+        en: tear down
 
 beißen:
   language: de
@@ -933,6 +1283,10 @@ beißen:
     präteritum: iss
     k2präsens: iss
     partizip: iss
+  variations:
+    - particle: zusammen
+      translations:
+        en: bite together      
 
 scheißen:
   language: de
@@ -989,6 +1343,16 @@ steigen:
     präteritum: ie
     k2präsens: ie
     partizip: ie
+  variations:
+    - particle: auf
+      translations:
+        en: [soar, ascend]
+    - particle: ab
+      translations:
+        en: [descend, dismount]
+    - particle: um
+      translations:
+        en: transfer (change buses, trains, planes)
 
 verzeihen:
   language: de
@@ -1023,6 +1387,28 @@ kommen:
   strong: true
   stems:
     präteritum: am
+  variations:
+    - particle: zusammen
+      translations:
+        en: meet, come together
+    - particle: zu
+      translations:
+        en: approach
+    - particle: weiter
+      translations:
+        en: [get further, make progress]
+    - particle: weg
+      translations:
+        en: get away      
+    - particle: vorbei
+      translations:
+        en: drop in      
+    - particle: vor
+      translations:
+        en: [happen, seem]      
+    - particle: um
+      translations:
+        en: get killed      
 
 nehmen:
   language: de
@@ -1034,6 +1420,13 @@ nehmen:
     duEs: imm
     präteritum: a
     partizip: omm
+  variations:
+    - particle: zu
+      translations:
+        en: [increase, gain weight]
+    - particle: vorweg
+      translations:
+        en: [anticipate, pre-empt, forestall]      
 
 sterben:
   language: de
@@ -1049,6 +1442,7 @@ sterben:
 
 brechen:
   language: de
+  hilfsverb: sein
   infinitive: brechen
   translations:
     en: break
@@ -1057,6 +1451,13 @@ brechen:
     duEs: i
     präteritum: a
     partizip: o
+  variations:
+    - particle: ab
+      translations:
+        en: break off
+    - particle: ein
+      translations:
+        en: [crack, burgle, collapse, break in, cave in]
 
 helfen:
   language: de
@@ -1079,6 +1480,14 @@ sprechen:
     duEs: i
     präteritum: a
     partizip: o
+  variations:
+    - particle: weiter
+      translations:
+        en: continue talking
+    - particle: nach
+      translations:
+        en: repeat after
+
 
 stechen:
   language: de
@@ -1124,6 +1533,20 @@ werfen:
     präteritum: a
     k2präsens: ü
     partizip: o
+  variations:
+    - particle: weg
+      translations:
+        en: throw away
+    - particle: um
+      translations:
+        en: knock over
+    - particle: nieder
+      sich: true
+      translations:
+        en: prostrate oneself
+    - particle: nieder
+      translations:
+        en: [overcome, defeat]
 
 schwimmen:
   language: de
@@ -1169,6 +1592,10 @@ binden:
   stems:
     präteritum: a
     partizip: u
+  variations:
+    - particle: zu
+      translations:
+        en: tie, tie up   
 
 finden:
   language: de
@@ -1179,6 +1606,14 @@ finden:
   stems:
     präteritum: a
     partizip: u
+  variations:
+    - particle: zurecht
+      sich: true
+      translations:
+        en: [find one's way, get one's bearings]
+    - particle: statt
+      translations:
+        en: take place
 
 trinken:
   language: de
@@ -1231,6 +1666,10 @@ singen:
   stems:
     präteritum: a
     partizip: u
+  variations:
+    - particle: vor
+      translations:
+        en: sing (in front of people)
 
 zwingen:
   language: de
@@ -1241,6 +1680,16 @@ zwingen:
   stems:
     präteritum: a
     partizip: u
+
+danken:
+  language: de
+  infinitive: danken
+  translations:
+    en: [thank]
+  variations:
+  - particle: ab
+    translations:
+      en: [abdicate, resign]
 
 #-------------------------------------------------------------------------------
 # ANACONDA ones from smarter german
@@ -1256,6 +1705,13 @@ brennen:
     präteritum: a
     k2präsens: e
     partizip: a
+  variations:
+    - particle: ab
+      translations:
+        en: burn down    
+    - particle: nieder
+      translations:
+        en: burn down    
 
 kennen:
   language: de
@@ -1278,6 +1734,13 @@ denken:
   stems:
     präteritum: ach
   weakEndings: true
+  variations:
+    - particle: aus
+      translations:
+        en: invent
+    - particle: um
+      translations:
+        en: [rethink, revise one's opinion]
 
 bringen:
   language: de
@@ -1288,6 +1751,25 @@ bringen:
   stems:
     präteritum: ach
   weakEndings: true
+  variations:
+    - particle: mit
+      translations:
+        en: [bring, bring along]
+    - particle: zu
+      translations:
+        en: bring
+    - particle: wieder
+      translations:
+        en: bring back
+    - particle: weg
+      translations:
+        en: take away
+    - particle: vor
+      translations:
+        en: [propose, bring forward, produce]
+    - particle: um
+      translations:
+        en: kill
 
 stehen:
   language: de
@@ -1364,24 +1846,17 @@ an|fangen:
   translations:
     en: begin
 
-an|sehen:
-  language: de
-  infinitive: an|sehen
-  translations:
-    en: inspect, view, look at, regard
-
-aus|sehen:
-  language: de
-  infinitive: aus|sehen
-  translations:
-    en: appear
-
 bekommen:
   language: de
   infinitive: bekommen
   translations:
     en: get
   hilfsverb: haben
+  variations:
+    - particle: wieder
+      translations:
+        en: get back
+
 
 #-------------------------------------------------------------------------------
 
@@ -1418,13 +1893,6 @@ ein|schlafen:
     en: fall asleep
   hilfsverb: sein
 
-ein|brechen:
-  language: de
-  infinitive: ein|brechen
-  translations:
-    en: [crack, burgle, collapse, break in, cave in]
-  hilfsverb: sein
-
 er|frieren:
   language: de
   infinitive: er|frieren
@@ -1432,25 +1900,15 @@ er|frieren:
     en: freeze to death
   hilfsverb: sein
 
-auf|steigen:
-  language: de
-  infinitive: auf|steigen
-  translations:
-    en: [soar, ascend]
-  hilfsverb: sein
-
-ab|steigen:
-  language: de
-  infinitive: ab|steigen
-  translations:
-    en: [descend, dismount]
-  hilfsverb: sein
-
 bestehen:
   language: de
   infinitive: bestehen
   translations:
     en: [persist, insist]
+  variations:
+    - particle: weiter
+      translations:
+        en: continue to exist      
 
 betreffen:
   language: de
@@ -1464,11 +1922,7 @@ bilden:
   translations:
     en: build
 
-dar|stellen:
-  language: de
-  infinitive: dar|stellen
-  translations:
-    en: [constitute, depict]
+
 
 entsprechen:
   language: de
@@ -1494,12 +1948,20 @@ erhalten:
   infinitive: erhalten
   translations:
     en: obtain
+  variations:
+    - particle: zurück
+      translations:
+        en: get back, be given back
 
 erkennen:
   language: de
   infinitive: erkennen
   translations:
     en: realize
+  variations:
+    - particle: zu
+      translations:
+        en: [bestow, confer (on)]
 
 erklären:
   language: de
@@ -1531,12 +1993,32 @@ erzählen:
   infinitive: erzählen
   translations:
     en: [tell, narrate, feel, sense]
+  variations:
+    - particle: weiter
+      translations:
+        en: tell further, continue a narration      
 
 führen:
   language: de
   infinitive: führen
   translations:
     en: lead, guide
+  variations:
+    - particle: zusammen
+      translations:
+        en: bring together  
+    - particle: zurück
+      translations:
+        en: trace back
+    - particle: weiter
+      translations:
+        en: continue
+    - particle: weg
+      translations:
+        en: lead off
+    - particle: vor
+      translations:
+        en: [bring forward, perform]
 
 interessieren:
   language: de
@@ -1557,6 +2039,13 @@ legen:
   infinitive: legen
   translations:
     en: [put, lay]
+  variations:
+    - particle: zurecht
+      translations:
+        en: lay out in readiness
+    - particle: vor
+      translations:
+        en: present 
 
 meinen:
   language: de
@@ -1581,12 +2070,22 @@ stellen:
   infinitive: stellen
   translations:
     en: [put, place]
-
-vor|stellen:
-  language: de
-  infinitive: vor|stellen
-  translations:
-    en: [introduce]
+  variations:
+    - particle: vor
+      translations:
+        en: [introduce]
+    - particle: dar
+      translations:
+        en: [constitute, depict]
+    - particle: her
+      translations:
+        en: [manufacture, produce]
+    - particle: um
+      translations:
+        en: rearrange
+    - particle: nach
+      translations:
+        en: readjust
 
 vergehen:
   language: de
@@ -1617,11 +2116,7 @@ zeigen:
   translations:
     en: exhibit, feature
 
-zu|hören:
-  language: de
-  infinitive: zu|hören
-  translations:
-    en: listen
+
 
 verstehen:
   language: de
@@ -1657,6 +2152,10 @@ entwickeln:
   infinitive: entwickeln
   translations:
     en: [develop, evolve]
+  variations:
+    - particle: weiter
+      translations:
+        en: develop further
 
 handeln:
   language: de
@@ -1682,11 +2181,7 @@ kosten:
   translations:
     en: cost
 
-mit|bringen:
-  language: de
-  infinitive: mit|bringen
-  translations:
-    en: [bring, bring along]
+
 
 packen:
   language: de
@@ -1760,18 +2255,13 @@ drehen:
   infinitive: drehen
   translations:
     en: [spin, turn, shoot (film)]
-
-her|stellen:
-  language: de
-  infinitive: her|stellen
-  translations:
-    en: [manufacture, produce]
-
-aus|denken:
-  language: de
-  infinitive: aus|denken
-  translations:
-    en: invent
+  variations:
+    - particle: zurück
+      translations:
+        en: turn back
+    - particle: um
+      translations:
+        en: turn around
 
 tauchen:
   language: de
@@ -1792,12 +2282,6 @@ ein|richten:
   translations:
     en: [establish, furnish, organize]
 
-aus|sagen:
-  language: de
-  infinitive: aus|sagen
-  translations:
-    en: [state, testify]
-
 sammeln:
   language: de
   infinitive: sammeln
@@ -1809,6 +2293,10 @@ wischen:
   infinitive: wischen
   translations:
     en: [wipe, mop]
+  variations:
+    - particle: weg
+      translations:
+        en: erase, wipe away
 
 erwischen:
   language: de
@@ -1827,12 +2315,6 @@ versetzen:
   infinitive: versetzen
   translations:
     en: [relocate, transfer, deploy, retort]
-
-auf|gehen:
-  language: de
-  infinitive: auf|gehen
-  translations:
-    en: [rise, realise, pan out, open]
 
 schnappen:
   language: de
@@ -1872,6 +2354,16 @@ fassen:
   infinitive: fassen
   translations:
     en: [grip, catch, comprehend, understand]
+  variations:
+    - particle: zusammen
+      translations:
+        en: summarize
+    - particle: zu
+      translations:
+        en: grab at      
+    - particle: um
+      translations:
+        en: [grasp, include, embrace]    
 
 wackeln:
   language: de
@@ -1884,6 +2376,15 @@ schauen:
   infinitive: schauen
   translations:
     en: [look, see]
+  variations:
+    - particle: um
+      sich: true
+      translations:
+        en: look around     
+    - particle: nach
+      sich: true
+      translations:
+        en: [look up, check up]    
 
 begreifen:
   language: de
@@ -1913,29 +2414,25 @@ an|rufen:
   translations:
     en: [call up]
 
-runter|fallen:
-  language: de
-  infinitive: runter|fallen
-  translations:
-    en: [go flying, tip over the edge]
-
 weinen:
   language: de
   infinitive: weinen
   translations:
     en: cry
-
-ein|fallen:
-  language: de
-  infinitive: ein|fallen
-  translations:
-    en: [collapse, shrink, dip, to occur to]
+  variations:
+    - particle: nach
+      translations:
+        en: mourn or bemoan the passing of
 
 räumen:
   language: de
   infinitive: räumen
   translations:
     en: [vacate, clear]
+  variations:
+    - particle: weg
+      translations:
+        en: clear away
 
 auf|räumen:
   language: de
@@ -1983,12 +2480,10 @@ stecken:
   infinitive: stecken
   translations:
     en: [stick, put, plug, thrust]
-
-auf|hören:
-  language: de
-  infinitive: auf|hören
-  translations:
-    en: [stop, end]
+  variations:
+    - particle: weg
+      translations:
+        en: [put away, withstand (a blow)]    
 
 #-------------------------------------------------------------------------------
 
@@ -2029,6 +2524,12 @@ weichen:
   # this may have variations
   translations:
     en: yeild
+  variations:
+    - particle: aus
+      dative: true
+      translations:
+        en: evade
+
 
 befehlen:
   language: de
@@ -2078,3 +2579,58 @@ blenden:
   variations:
     - definition: fade
       pariticle: ab
+      translations:
+        en: [fade out, dim (lights)]
+    - particle: zurück
+      translations:
+        en: flash back (film)
+
+passen:
+  language: de
+  infinitive: passen
+  translations:
+    en: [fit]
+  variations:
+    - particle: zusammen
+      translations:
+        en: be suited for each other
+
+weisen: 
+  language: de
+  stems:
+    präteritum: u
+    partizip: u
+  translations:
+    en: point
+  variations:
+    - particle: zurück
+      translations:
+        en: refuse, send back   
+    - particle: zurecht
+      translations:
+        en: rebuke, reprimand
+    - particle: nach
+      translations:
+        en: provide proof of something that has been committed
+
+drücken:
+  language: de
+  translations:
+    en: press
+  variations:
+    - particle: zu
+      translations:
+        en: cover up, tuck in
+    - particle: zu
+      translations:
+        en: press shut
+    - particle: ab
+      translations:
+        en: [pull the trigger, shoot]
+    - particle: nach
+      translations:
+        en: move up (to the next position after it has become vacant)
+    - particle: vor
+      translations:
+        en: move forward
+

--- a/apps/db_management/src/data/grouped_germanSeparable.yaml
+++ b/apps/db_management/src/data/grouped_germanSeparable.yaml
@@ -1,0 +1,840 @@
+reichen:
+  - particle: hinein
+    translations:
+      en: reach into
+  - particle: hin
+    translations:
+      en: suffice
+  - particle: aus
+    translations:
+      en: be sufficient
+  - particle: nach
+    translations:
+      en: hand in later
+holen:
+  - particle: wieder
+    translations:
+      en: repeat
+  - particle: nach
+    translations:
+      en:
+        - catch up on
+        - make up for
+        - fetch later
+  - particle: herunter
+    translations:
+      en: fetch down
+  - particle: herein
+    translations:
+      en: bring in
+  - particle: herbei
+    translations:
+      en: fetch
+drängen:
+  - particle: hinein
+    translations:
+      en: fall into
+  - particle: vor
+    translations:
+      en: push forward
+lehnen:
+  - particle: zurück
+    translations:
+      en: lean back
+  - particle: an
+    translations:
+      en: lean
+treiben:
+  - particle: fort
+    translations:
+      en:
+        - drive away
+        - drift away
+        - continue on with
+  - particle: ab
+    translations:
+      en: abort
+stimmen:
+  - particle: um
+    translations:
+      en: persuade [to change one's mind]
+  - particle: ab
+    translations:
+      en: vote
+schicken:
+  - particle: ab
+    translations:
+      en: send off
+  - particle: vorweg
+    translations:
+      en: send off in anticipation
+  - particle: hinterher
+    translations:
+      en:
+        - send after
+        - send on
+  - particle: hin
+    translations:
+      en: send there
+  - particle: herüber
+    translations:
+      en: send over here
+fegen:
+  - particle: ab
+    translations:
+      en: brush off
+  - particle: weg
+    translations:
+      en: sweep away
+hacken:
+  - particle: ab
+    translations:
+      en: chop off
+lenken:
+  - particle: ab
+    translations:
+      en: divert
+  - particle: fern
+    translations:
+      en: steer by remote control
+  - particle: hin
+    translations:
+      en: steer toward
+nutzen:
+  - particle: ab
+    translations:
+      en: wear out
+riegeln:
+  - particle: ab
+    translations:
+      en:
+        - bolt (a door)
+        - close off
+sichern:
+  - particle: ab
+    translations:
+      en: secure
+wehren:
+  - particle: ab
+    translations:
+      en:
+        - repulse
+        - fend off
+zweigen:
+  - particle: ab
+    translations:
+      en: branch off
+dauern:
+  - particle: an
+    translations:
+      en: last, continue
+
+lächeln:
+  - particle: an
+    translations:
+      en: smile at
+merken:
+  - particle: an
+    translations:
+      en:
+        - notice
+        - note
+
+
+rechnen:
+  - particle: an
+    translations:
+      en: take into account
+  - particle: hoch
+    translations:
+      en: extrapolate to project [a forecast]
+  - particle: um
+    translations:
+      en: convert (e.g. into different units)
+
+schneiden:
+  - particle: an
+    translations:
+      en: cut into (cut the first piece of)
+  - particle: auf
+    translations:
+      en: cut open
+  - particle: durch
+    translations:
+      en: cut through
+  - particle: ein
+    translations:
+      en: make a cut in
+  - particle: hinein
+    translations:
+      en: cut into
+
+streben:
+  - particle: an
+    translations:
+      en: aspire
+  - particle: empor
+    translations:
+      en: aspire
+strengen:
+  - particle: an
+    translations:
+      en: strain
+tippen:
+  - particle: an
+    translations:
+      en: give a light tap to
+zünden:
+  - particle: an
+    translations:
+      en: ignite
+bessern:
+  - particle: auf
+    translations:
+      en: improve
+  - particle: aus
+    translations:
+      en: fix, touch up
+  - particle: nach
+    translations:
+      en:
+        - touch up
+        - improve by making adjustments
+bewahren:
+  - particle: auf
+    translations:
+      en: keep, store
+blühen:
+  - particle: auf
+    translations:
+      en: blossom forth
+
+
+decken:
+  - particle: auf
+    translations:
+      en: uncover
+
+klären:
+  - particle: auf
+    translations:
+      en: enlighten
+
+pumpen:
+  - particle: auf
+    translations:
+      en: inflate
+
+tischen:
+  - particle: auf
+    translations:
+      en: serve up
+
+
+beuten:
+  - particle: aus
+    translations:
+      en: exploit
+breiten:
+  - particle: aus
+    translations:
+      en: spread out
+
+dehnen:
+  - particle: aus
+    translations:
+      en: extend, expand
+diskutieren:
+  - particle: aus
+    translations:
+      en: discuss thoroughly
+
+füllen:
+  - particle: aus
+    translations:
+      en: fill out [a form]
+  - particle: nach
+    translations:
+      en:
+        - refill
+        - top off
+  - particle: um
+    translations:
+      en: transfer (something) into (another container)
+
+klammern:
+  - particle: aus
+    translations:
+      en: bracket out
+  - particle: ein
+    translations:
+      en: put in brackets
+  - particle: um
+    translations:
+      en: clutch
+klingen:
+  - particle: aus
+    translations:
+      en: fade away [music]
+lachen:
+  - particle: aus
+    translations:
+      en: laugh at
+
+pressen:
+  - particle: aus
+    translations:
+      en: press or squeeze out
+quetschen:
+  - particle: aus
+    translations:
+      en: press or squeeze out
+radieren:
+  - particle: aus
+    translations:
+      en: erase
+rotten:
+  - particle: aus
+    translations:
+      en: eradicate
+rüsten:
+  - particle: aus
+    translations:
+      en: equip
+
+
+schütten:
+  - particle: aus
+    translations:
+      en: spill out, tip out
+
+wechseln:
+  - particle: aus
+    translations:
+      en: switch, replace.
+
+haltem:
+  - particle: auseinander
+    translations:
+      en: distinguish, keep apart
+
+behalten:
+  - particle: bei
+    translations:
+      en: retain
+  - particle: vor
+    translations:
+      en: reserve
+fügen:
+  - particle: bei
+    translations:
+      en: enclose [along with]
+  - particle: hinzu
+    translations:
+      en:
+        - add
+        - append
+
+mischen:
+  - particle: bei
+    translations:
+      en: add [to a mixture]
+
+
+kämmen:
+  - particle: durch
+    translations:
+      en: comb through [hair]
+schlüpfen:
+  - particle: durch
+    translations:
+      en: slip through
+stoßen:
+  - particle: durch
+    translations:
+      en: knock a hole through
+  - particle: zusammen
+    translations:
+      en: collide, clash
+wählen:
+  - particle: durch
+    translations:
+      en: dial directly
+berufen:
+  - particle: ein
+    translations:
+      en: conscript, convene
+
+cremen:
+  - particle: ein
+    translations:
+      en: put lotion on
+dringen:
+  - particle: ein
+    translations:
+      en: enter forcibly into
+kalkulieren:
+  - particle: ein
+    translations:
+      en: take into account
+
+kellern:
+  - particle: ein
+    translations:
+      en: store in the cellar
+
+leiten:
+  - particle: ein
+    translations:
+      en: introduce, begin
+marschieren:
+  - particle: ein
+    translations:
+      en: march in
+ordnen:
+  - particle: ein
+    translations:
+      en: put into order
+parken:
+  - particle: ein
+    translations:
+      en: park [in a parking space]
+sacken:
+  - particle: ein
+    translations:
+      en: pocket
+schreiten:
+  - particle: ein
+    translations:
+      en: intervene
+
+
+willigen:
+  - particle: ein
+    translations:
+      en: agree [to], consent
+zahlen:
+  - particle: ein
+    translations:
+      en: pay in, pay a deposit).
+  - particle: heim
+    translations:
+      en:
+        - pay back
+        - get even with
+blicken:
+  - particle: empor
+    translations:
+      en: raise one's eyes
+  - particle: hinunter
+    translations:
+      en: look down
+  - particle: hinab
+    translations:
+      en: look down
+  - particle: um
+    translations:
+      en: look around
+
+ragen:
+  - particle: empor
+    translations:
+      en: tower above
+  - particle: hervor
+    translations:
+      en: project, jut out, stand out
+  - particle: hinaus
+    translations:
+      en: project beyond
+
+wirken:
+  - particle: entgegen
+    translations:
+      en: counteract
+  - particle: mit
+    translations:
+      en: be involved
+  - particle: nach
+    translations:
+      en: have a lasting effect
+
+besetzen:
+  - particle: fehl
+    translations:
+      en: miscast [in film or theater]
+starten:
+  - particle: fehl
+    translations:
+      en: make a false start
+bedienen:
+  - particle: fern
+    translations:
+      en: operate by remote control
+
+
+kleben:
+  - particle: fest
+    translations:
+      en:
+        - glue on
+        - be glued on
+nageln:
+  - particle: fest
+    translations:
+      en: nail down
+pflanzen:
+  - particle: fort
+    translations:
+      en: propagate
+kämpfen:
+  - particle: frei
+    translations:
+      en: liberate
+begleiten:
+  - particle: heim
+    translations:
+      en: accompany home
+  - particle: hin
+    translations:
+      en: accompany thither
+kehren:
+  - particle: heim
+    translations:
+      en: return home
+  - particle: um
+    translations:
+      en: turn around
+  - particle: wieder
+    translations:
+      en: return
+
+
+mindern:
+  - particle: herab
+    translations:
+      en: reduce, disparage
+
+
+stürzen:
+  - particle: herab
+    translations:
+      en: plummet down
+reifen:
+  - particle: heran
+    translations:
+      en: mature
+beschwören:
+  - particle: herauf
+    translations:
+      en:
+        - cause
+        - bring about
+        - evoke
+
+kriegen:
+  - particle: heraus
+    translations:
+      en:
+        - get out of
+        - find out
+  - particle: hin
+    translations:
+      en: manage to take care of, make (something) function
+  - particle: los
+    translations:
+      en: get rid of
+fordern:
+  - particle: heraus
+    translations:
+      en:
+        - challenge
+        - provoke
+
+sehnen:
+  - particle: herbei
+    translations:
+      en: long for
+schneien:
+  - particle: herein
+    translations:
+      en: snow in, appear out of the blue
+spazieren:
+  - particle: herein
+    translations:
+      en: stroll in
+
+schlucken:
+  - particle: herunter
+    translations:
+      en: swallow
+schrauben:
+  - particle: herunter
+    translations:
+      en:
+        - ratchet down
+        - dumb down
+
+wagen:
+  - particle: sich hervor
+    translations:
+      en: dare to come out
+blättern:
+  - particle: hin
+    translations:
+      en: shell out
+
+geraten:
+  - particle: hin
+    translations:
+      en: get there
+horchen:
+  - particle: hin
+    translations:
+      en: listen closely
+knien:
+  - particle: hin
+    translations:
+      en: kneel down
+  - particle: nieder
+    translations:
+      en: kneel down
+
+schleppen:
+  - particle: hin
+    translations:
+      en: the drag there
+spülen:
+  - particle: hinunter
+    translations:
+      en: wash down
+ekeln:
+  - particle: hinaus
+    translations:
+      en: drive out in disgust
+
+zögern:
+  - particle: hinaus
+    translations:
+      en: draw out, delay
+
+eversetzen:
+  - particle: sich hinein
+    translations:
+      en: put oneself into (someone's situation)
+
+hinken:
+  - particle: hinterher
+    translations:
+      en: limp along behind
+gesellen:
+  - particle: hinzu
+    translations:
+      en: join
+verdienen:
+  - particle: hinzu
+    translations:
+      en: earn (something) extra
+krempeln:
+  - particle: hoch
+    translations:
+      en: roll up [a sleeve]
+
+affen:
+  - particle: nach
+    translations:
+      en:
+        - mimic
+        - ape
+ahmen:
+  - particle: nach
+    translations:
+      en: imitate
+drucken:
+  - particle: nach
+    translations:
+      en: reprint
+empfinden:
+  - particle: nach
+    translations:
+      en: empathize
+fühlen:
+  - particle: nach
+    translations:
+      en: empathize
+
+
+feiern:
+  - particle: nach
+    translations:
+      en: celebrate at a later date
+
+forschen:
+  - particle: nach
+    translations:
+      en: investigate
+haken:
+  - particle: nach
+    translations:
+      en:
+        - dig deeper
+        - ask further about
+trauern:
+  - particle: nach
+    translations:
+      en: mourn or bemoan the passing of
+vollziehen:
+  - particle: nach
+    translations:
+      en: comprehend
+zählen:
+  - particle: nach
+    translations:
+      en: recount (count again)
+  - particle: zusammen
+    translations:
+      en: add up
+brüllen:
+  - particle: nieder
+    translations:
+      en: shout down
+ändern:
+  - particle: um
+    translations:
+      en: change, change around
+benennen:
+  - particle: um
+    translations:
+      en: rename
+buchen:
+  - particle: um
+    translations:
+      en: re-book (travel plans)
+formen:
+  - particle: um
+    translations:
+      en: recast
+funktionieren:
+  - particle: um
+    translations:
+      en: change the function of
+hauen:
+  - particle: um
+    translations:
+      en: knock down, knock over
+kippen:
+  - particle: um
+    translations:
+      en: tip over
+kreisen:
+  - particle: um
+    translations:
+      en: orbit
+rahmen:
+  - particle: um
+    translations:
+      en: frame
+rühren:
+  - particle: um
+    translations:
+      en: stir
+schalten:
+  - particle: um
+    translations:
+      en: change, switch (gears, channels)
+schulen:
+  - particle: um
+    translations:
+      en: retrain, switch to another school
+spulen:
+  - particle: um
+    translations:
+      en: rewind
+tauschen:
+  - particle: um
+    translations:
+      en: exchange
+bereiten:
+  - particle: vor
+    translations:
+      en: prepare
+beugen:
+  - particle: vor
+    translations:
+      en:
+        - prevent
+        - bend forward
+herrschen:
+  - particle: vor
+    translations:
+      en: predominate
+neigen:
+  - particle: vor
+    translations:
+      en: lean forward
+programmieren:
+  - particle: vor
+    translations:
+      en: pre-program
+sorgen:
+  - particle: vor
+    translations:
+      en: make provisions
+berechnen:
+  - particle: voraus
+    translations:
+      en: calculate in advance
+eilen:
+  - particle: vorüber
+    translations:
+      en: hurry past
+blasen:
+  - particle: weg
+    translations:
+      en: blow away
+
+
+jagen:
+  - particle: weg
+    translations:
+      en: chase away
+beleben:
+  - particle: wieder
+    translations:
+      en: resuscitate
+entdecken:
+  - particle: wieder
+    translations:
+      en: rediscover
+herstellen:
+  - particle: wieder
+    translations:
+      en: restore, reestablish
+käuen:
+  - particle: wieder
+    translations:
+      en: ruminate
+vereinigen:
+  - particle: wieder
+    translations:
+      en: reunite
+billigen:
+  - particle: zu
+    translations:
+      en: grant, allow
+
+erobern:
+  - particle: zurück
+    translations:
+      en: recapture
+schrecken:
+  - particle: zurück
+    translations:
+      en: shrink back, shrink from, recoil
+klappen:
+  - particle: zusammen
+    translations:
+      en: fold up, shut
+
+sich dar|anmachen:
+  translations:
+    en: set about it, get down to it


### PR DESCRIPTION
Updated german verb yaml so that variations with simple particles are now variations under the main verb.

Also created a script that takes file paths as arguments to sort particles, and then ran that against the german separable verb file. Complex variations were added to `_germanVerbs2.yaml` for future consideration.
