### PR TITLE
Populate german

### DIFF
--- a/apps/db_management/src/db-types/germanDBModel.ts
+++ b/apps/db_management/src/db-types/germanDBModel.ts
@@ -16,7 +16,15 @@ export const convertGermanVerbToHydratedGermanVerb = (
 
   const germanVerbVariations = variations.map((variation) => {
     const tenses: GermanVerbTenseModel[] = [];
-    const { hilfsverb, partizip, particle, translations } = variation;
+    const {
+      dative = false,
+      genitive = false,
+      hilfsverb,
+      impersonal = false,
+      particle = '',
+      partizip,
+      translations,
+    } = variation;
 
     for (const [keyword, value] of Object.entries(variation)) {
       if (germanTenses.includes(keyword)) {
@@ -35,7 +43,10 @@ export const convertGermanVerbToHydratedGermanVerb = (
     }
 
     return {
+      dative,
+      genitive,
       hilfsverb,
+      impersonal,
       particle,
       partizip,
       tenses,

--- a/apps/db_management/src/db-types/germanDBModelSpecConstants.ts
+++ b/apps/db_management/src/db-types/germanDBModelSpecConstants.ts
@@ -45,9 +45,12 @@ export const expected = {
   schema_version: 1,
   variations: [
     {
+      dative: false,
+      genitive: false,
       hilfsverb: 'haben',
+      impersonal: false,
       partizip: 'geblendet',
-      particle: undefined,
+      particle: '',
       tenses: [
         {
           tenseName: 'präsens',
@@ -155,7 +158,10 @@ export const expected = {
       },
     },
     {
+      dative: false,
+      genitive: false,
       hilfsverb: 'haben',
+      impersonal: false,
       partizip: 'abgeblendet',
       particle: 'ab',
       tenses: [
@@ -265,7 +271,10 @@ export const expected = {
       },
     },
     {
+      dative: false,
+      genitive: false,
       hilfsverb: 'haben',
+      impersonal: false,
       particle: 'ab',
       partizip: 'geblendet',
       tenses: [

--- a/apps/db_management/src/db-types/germanVerbHydratedModel.ts
+++ b/apps/db_management/src/db-types/germanVerbHydratedModel.ts
@@ -14,9 +14,12 @@ export interface GermanVerbTenseModel {
 }
 
 export interface GermanVerbVariationModel {
+  dative: boolean;
+  genitive: boolean;
   hilfsverb: string;
-  partizip: string;
+  impersonal: boolean;
   particle: string;
+  partizip: string;
   tenses: GermanVerbTenseModel[];
   translations: TranslationDictionaryModel[];
 }
@@ -39,9 +42,12 @@ const TenseSchema = new Schema({
 });
 
 const GermanVariationSchema = new Schema({
+  dative: { type: Boolean, required: true },
+  genitive: { type: Boolean, required: true },
   hilfsverb: { type: String, required: true },
-  partizip: { type: String, required: true },
+  impersonal: { type: String, required: true },
   particle: { type: String, required: false },
+  partizip: { type: String, required: true },
   tenses: { type: [TenseSchema], required: true },
   translations: {
     type: Schema.Types.Mixed,

--- a/apps/db_management/src/db-types/germanVerbHydratedModel.ts
+++ b/apps/db_management/src/db-types/germanVerbHydratedModel.ts
@@ -58,7 +58,7 @@ const GermanVariationSchema = new Schema({
 
 export const GermanVerbHydratedSchema = new Schema({
   date: { type: Date, required: true },
-  infinitive: { type: String, required: true },
+  infinitive: { type: String, required: true, unique: true },
   schema_version: { type: Number, required: true },
   variations: { type: [GermanVariationSchema], required: true },
 });

--- a/apps/db_management/src/routes/populate/PopulateRoutes.ts
+++ b/apps/db_management/src/routes/populate/PopulateRoutes.ts
@@ -2,8 +2,6 @@ import { RequestHandler, Router } from 'express';
 import { buildAllSource } from '@controllers/PopulateController';
 import path from 'path';
 
-import { insertGermanVerbs } from '../../services/insertGermanVerbs';
-
 export const populateRouter: Router = Router();
 
 populateRouter.get('/', (_, res) => {

--- a/apps/db_management/src/services/insertGermanVerbs.ts
+++ b/apps/db_management/src/services/insertGermanVerbs.ts
@@ -1,5 +1,8 @@
 import { convertGermanVerbToHydratedGermanVerb } from 'db-types/germanDBModel';
-import { GermanVerbHydratedSchema } from 'db-types/germanVerbHydratedModel';
+import {
+  GermanVerbHydratedModel,
+  GermanVerbHydratedSchema,
+} from 'db-types/germanVerbHydratedModel';
 import { GermanVerbHydrated } from 'german-types';
 import { LanguageVerbBase } from 'global-types';
 
@@ -19,15 +22,30 @@ export const insertGermanVerbs = async (
     GermanVerbHydratedSchema,
   );
 
-  const hydratedSchema = convertGermanVerbToHydratedGermanVerb(
-    de[0] as GermanVerbHydrated,
-  );
+  // if de.length is over 100k, chunck the write
+  const writeGroups: GermanVerbHydratedModel[][] = [];
+  let source = [...de];
+  do {
+    const newGroup = source
+      .splice(0, 999_999)
+      .map((verbRecord) =>
+        convertGermanVerbToHydratedGermanVerb(verbRecord as GermanVerbHydrated),
+      );
 
-  const newVerb = new GermanModel(hydratedSchema);
+    writeGroups.push(newGroup);
+  } while (source.length > 0);
 
   try {
-    const message = await newVerb.save();
-    return `New verb was successfully saved to the database.`;
+    const German = mongoose.model('GermanVerbModel', GermanVerbHydratedSchema);
+    await Promise.all(
+      writeGroups.map((writeGroup) => {
+        German.insertMany(writeGroup);
+      }),
+    ).then(() => {
+      console.log(`Operation complete`);
+    });
+
+    return `New verbs were successfully saved to the database.`;
   } catch (err: unknown) {
     if (err instanceof Error) {
       return ` Error: ${err.message}`;

--- a/apps/db_management/src/services/insertGermanVerbs.ts
+++ b/apps/db_management/src/services/insertGermanVerbs.ts
@@ -27,7 +27,6 @@ export const insertGermanVerbs = async (
 
   try {
     const message = await newVerb.save();
-    console.log(message);
     return `New verb was successfully saved to the database.`;
   } catch (err: unknown) {
     if (err instanceof Error) {

--- a/apps/db_management/src/views/populate.ejs
+++ b/apps/db_management/src/views/populate.ejs
@@ -3,7 +3,7 @@
  <div class="ui segment">
   <h1>Welcome to populate.</h1>
    
-  <button onclick="populateGerman()">Populate haben in German</button>
+  <button onclick="populateGerman()">Populate German Verbs</button>
 
   <button onclick="downloadAll()">Download</button>
  </div>


### PR DESCRIPTION
Updated the `insertGermanVerbs` service to populate the mongo db with the initial 200+ verb records.

As the final schema (v1) for German, variations include
| property | type | mandatory |
|---|---|---|
| dative | boolean | X |
| genitive | boolean | X |
| impersonal  | boolean | X |
| hilfsverb  | string | X |
| particle | string | _ |
| partizip | string | X |
| tenses | [`pronoun`: string] | X |
| translations | [ `language key`: string] | X |

 to the model and the schema.

The infinitive at the parent level is a `unique` key. 

