### PR TITLE
feat: create conjugation for boire

### DIFF
--- a/apps/db_management/src/data/frenchVerbs.yaml
+++ b/apps/db_management/src/data/frenchVerbs.yaml
@@ -321,253 +321,253 @@ voyager:
 
 appeler:
   language: fr
-  boot: true
+  pattern: boot
   translations:
     en: call
 
 chanceler:
   language: fr
-  boot: true
+  pattern: boot
   translations:
     en: [totter, wobble]
 
 épeler:
   language: fr
-  boot: true
+  pattern: boot
   translations:
     en: spell
 
 rappeler:
   language: fr
-  boot: true
+  pattern: boot
   translations:
     en: [call back, recall]
 
 renouveler:
   language: fr
-  boot: true
+  pattern: boot
   translations:
     en: renew
 
 ruisseler:
   language: fr
-  boot: true
+  pattern: boot
   translations:
     en: [flow, stream]
 
 feuilleter:
   language: fr
-  boot: true
+  pattern: boot
   translations:
     en: [leaf through]
 
 hoqueter:
   language: fr
-  boot: true
+  pattern: boot
   translations:
     en: hiccup
 
 jeter:
   language: fr
-  boot: true
+  pattern: boot
   translations:
     en: throw
 
 projeter:
   language: fr
-  boot: true
+  pattern: boot
   translations:
     en: project
 
 rejeter:
   language: fr
-  boot: true
+  pattern: boot
   translations:
     en: reject
 
 piéger:
   language: fr
-  boot: true
+  pattern: boot
   translations:
     en: trap
 
 appeler:
   language: fr
-  boot: true
+  pattern: boot
   translations:
     en: call
 
 chanceler:
   language: fr
-  boot: true
+  pattern: boot
   translations:
     en: [totter, wobble]
 
 épeler:
   language: fr
-  boot: true
+  pattern: boot
   translations:
     en: spell
 
 rappeler:
   language: fr
-  boot: true
+  pattern: boot
   translations:
     en: [call back, recall]
 
 renouveler:
   language: fr
-  boot: true
+  pattern: boot
   translations:
     en: renew
 
 ruisseler:
   language: fr
-  boot: true
+  pattern: boot
   translations:
     en: [flow, stream]
 
 feuilleter:
   language: fr
-  boot: true
+  pattern: boot
   translations:
     en: [leaf through]
 
 hoqueter:
   language: fr
-  boot: true
+  pattern: boot
   translations:
     en: hiccup
 
 jeter:
   language: fr
-  boot: true
+  pattern: boot
   translations:
     en: throw
 
 projeter:
   language: fr
-  boot: true
+  pattern: boot
   translations:
     en: project
 
 rejeter:
   language: fr
-  boot: true
+  pattern: boot
   translations:
     en: reject
 
 abréger:
   language: fr
-  boot: true
+  pattern: boot
   translations:
     en: [shorten, abridge]
 
 protéger:
   language: fr
-  boot: true
+  pattern: boot
   translations:
     en: protect
 
 broyer:
   language: fr
-  boot: true
+  pattern: boot
   translations:
     en: grind
 
 employer:
   language: fr
-  boot: true
+  pattern: boot
   translations:
     en: employ
 
 envoyer:
   language: fr
-  boot: true
+  pattern: boot
   translations:
     en: send
 
 nettoyer:
   language: fr
-  boot: true
+  pattern: boot
   translations:
     en: clean
 
 se noyer:
   language: fr
-  boot: true
+  pattern: boot
   translations:
     en: drown
 
 renvoyer:
   language: fr
-  boot: true
+  pattern: boot
   translations:
     en: fire
 
 tutoyer:
   language: fr
-  boot: true
+  pattern: boot
   translations:
     en: use tu
 
 vouvoyer:
   language: fr
-  boot: true
+  pattern: boot
   translations:
     en: use vous
 
 appuyer:
   language: fr
-  boot: true
+  pattern: boot
   translations:
     en: [lean, press]
 
 ennuyer:
   language: fr
-  boot: true
+  pattern: boot
   translations:
     en: bore
 
 essuyer:
   language: fr
-  boot: true
+  pattern: boot
   translations:
     en: wipe
 
 balayer:
   language: fr
-  boot: true
+  pattern: boot
   translations:
     en: sweep
 
 effrayer:
   language: fr
-  boot: true
+  pattern: boot
   translations:
     en: frighten
 
 égayer:
   language: fr
-  boot: true
+  pattern: boot
   translations:
     en: cheer up
 
 essayer:
   language: fr
-  boot: true
+  pattern: boot
   translations:
     en: try
 
 payer:
   language: fr
-  boot: true
+  pattern: boot
   translations:
     en: pay
 
 rayer:
   language: fr
-  boot: true
+  pattern: boot
   translations:
     en: [draw a line (on/through), to cross out]
 
@@ -903,6 +903,7 @@ déduire:
   language: fr
   translations:
     en: [deduce, deduct]
+
 détruire:
   language: fr
   translations:
@@ -1081,67 +1082,67 @@ transcrire:
 
 adjoindre:
   language: fr
-  indre: true
+  pattern: indre
   translations:
     en: appoint
 
 astreindre:
   language: fr
-  indre: true
+  pattern: indre
   translations:
     en: [compel, force]
 
 atteindre:
   language: fr
-  indre: true
+  pattern: indre
   translations:
     en: [attain, reach]
 
 ceindre:
   language: fr
-  indre: true
+  pattern: indre
   translations:
     en: [don, put on]
 
 contraindre:
   language: fr
-  indre: true
+  pattern: indre
   translations:
     en: [force, compel]
 
 craindre:
   language: fr
-  indre: true
+  pattern: indre
   translations:
     en: fear
 
 dépeindre:
   language: fr
-  indre: true
+  pattern: indre
   translations:
     en: depict
 
 déteindre:
   language: fr
-  indre: true
+  pattern: indre
   translations:
     en: [bleach, leach]
 
 disjoindre:
   language: fr
-  indre: true
+  pattern: indre
   translations:
     en: [disconnect, separate]
 
 empreindre:
   language: fr
-  indre: true
+  pattern: indre
   translations:
     en: imprint
 
 enfreindre:
   language: fr
-  indre: true
+  pattern: indre
   translations:
     en: [infringe, break]
   notes:
@@ -1149,263 +1150,267 @@ enfreindre:
 
 enjoindre:
   language: fr
-  indre: true
+  pattern: indre
   translations:
     en: enjoin (someone to do)
   notes: formal
 
 épreindre:
   language: fr
-  indre: true
+  pattern: indre
   translations:
     en: juice
   notes: old-fashioned
 
 éteindre:
   language: fr
-  indre: true
+  pattern: indre
   translations:
     en: [extinguish, snuff out]
 
 étreindre:
   language: fr
-  indre: true
+  pattern: indre
   translations:
     en: [embrace, clutch]
   notes: formal
 
 feindre:
   language: fr
-  indre: true
+  pattern: indre
   translations:
     en: feign
 
 geindre:
   language: fr
-  indre: true
+  pattern: indre
   translations:
     en: [groan, whine]
 
 joindre:
   language: fr
-  indre: true
+  pattern: indre
   translations:
     en: join
 
 oindre:
   language: fr
-  indre: true
+  pattern: indre
   translations:
     en: anoint
 
 peindre:
   language: fr
-  indre: true
+  pattern: indre
   translations:
     en: paint
 
 plaindre:
   language: fr
-  indre: true
+  pattern: indre
   translations:
     en: [pity, feel sorry for]
 
 rejoindre:
   language: fr
-  indre: true
+  pattern: indre
   translations:
     en: [rejoin, get back to]
 
 repeindre:
   language: fr
-  indre: true
+  pattern: indre
   translations:
     en: repaint
 
 restreindre:
   language: fr
-  indre: true
+  pattern: indre
   translations:
     en: [restrict, limit]
 
 reteindre:
   language: fr
-  indre: true
+  pattern: indre
   translations:
     en: [dye again, redye]
 
 teindre:
   language: fr
-  indre: true
+  pattern: indre
   translations:
     en: dye
 
 abattre:
   language: fr
-  ttre: true
+  pattern: ttre
   translations:
     en: [knock down, weaken]
 
 admettre:
   language: fr
-  ttre: true
+  pattern: ttre
   translations:
     en: admit
 
 battre:
   language: fr
-  ttre: true
+  pattern: ttre
   translations:
     en: beat
 
 combattre:
   language: fr
-  ttre: true
+  pattern: ttre
   translations:
     en: [combat, fight]
 
 commettre:
   language: fr
-  ttre: true
+  pattern: ttre
   translations:
     en: commit
 
 compromettre:
   language: fr
-  ttre: true
+  pattern: ttre
   translations:
     en: compromise
 
 débattre:
   language: fr
-  ttre: true
+  pattern: ttre
   translations:
     en: debate
 
 mettre:
   language: fr
-  ttre: true
+  pattern: ttre
   translations:
     en: put
 
 permettre:
   language: fr
-  ttre: true
+  pattern: ttre
   translations:
     en: permit
 
 promettre:
   language: fr
-  ttre: true
+  pattern: ttre
   translations:
     en: promise
 
 soumettre:
   language: fr
-  ttre: true
+  pattern: ttre
   translations:
     en: submit
 
 transmettre:
   language: fr
-  ttre: true
+  pattern: ttre
   translations:
     en: transmit
 
 apprendre:
   language: fr
-  rendre: true
+  pattern: rendre
   translations:
     en: learn
 
 comprendre:
   language: fr
-  rendre: true
+  pattern: rendre
   translations:
     en: understand
 
 entreprendre:
   language: fr
-  rendre: true
+  pattern: rendre
   translations:
     en: undertake
 
 méprendre:
   language: fr
-  rendre: true
+  pattern: rendre
   reflexive: true
   translations:
     en: be mistaken
 
 prendre:
   language: fr
-  rendre: true
+  pattern: rendre
   translations:
     en: take
 
 reprendre:
   language: fr
-  rendre: true
+  pattern: rendre
   translations:
     en: [take again, retake]
 
 surprendre:
   language: fr
-  rendre: true
+  pattern: rendre
   translations:
     en: surprise
 
-
 apparaître:
   language: fr
-  aitre: true
+  pattern: aitre
   translations:
     en: appear
 
 comparaître:
   language: fr
-  aitre: true
+  pattern: aitre
   translations:
     en: appear in court
 
 connaître:
   language: fr
-  aitre: true
+  pattern: aitre
   translations:
     en: [know, be familiar with]
 
 disparaître:
   language: fr
-  aitre: true
+  pattern: aitre
   translations:
     en: disappear
 
 méconnaître:
   language: fr
-  aitre: true
+  pattern: aitre
   translations:
     en: be unaware of
 
 paraître:
   language: fr
-  aitre: true
+  pattern: aitre
   translations:
     en: seem
 
 reconnaître:
   language: fr
-  aitre: true
+  pattern: aitre
   translations:
     en: recognize
 
 reparaître:
   language: fr
-  aitre: true
+  pattern: aitre
   translations:
     en: reappear
 
 transparaître:
   language: fr
-  aitre: true
+  pattern: aitre
   translations:
     en: show through
+
+boire:
+  language: fr
+  translations:
+    en: drink

--- a/apps/db_management/src/models/french/createStandardConjugation.ts
+++ b/apps/db_management/src/models/french/createStandardConjugation.ts
@@ -2,10 +2,11 @@ import { erConjugation } from "@models/french/createStandardErConjugation";
 import { irConjugation } from "@models/french/createStandardIrConjugation";
 import { reConjugation } from "@models/french/createStandardReConjugation";
 import { BaseFrenchVerb } from "@models/french/frenchTypes";
+import { FrenchBaseVerbConjugation } from "french-types";
 
-type ConjugationFunction = (infinitive: string, stem: string) => BaseFrenchVerb;
+type ConjugationFunction = (infinitive: string, stem: string) => FrenchBaseVerbConjugation;
 
-export const createStandardConjugation = (infinitive: string, helper_verb?: string): BaseFrenchVerb => {
+export const createStandardConjugation = (infinitive: string, helper_verb?: string): FrenchBaseVerbConjugation => {
   const ending = infinitive.slice(-2);
   const stem = infinitive.slice(0, -2)
 
@@ -17,7 +18,7 @@ export const createStandardConjugation = (infinitive: string, helper_verb?: stri
 
   if (ending in strategy) {
     const verb = strategy[ending](infinitive, stem)
-    if (helper_verb) {
+    if (helper_verb === 'être') {
       verb.helper_verb = helper_verb;
     }
     return verb;

--- a/apps/db_management/src/models/french/createStandardErConjugation.ts
+++ b/apps/db_management/src/models/french/createStandardErConjugation.ts
@@ -1,7 +1,7 @@
 import { BaseFrenchVerb } from "@models/french/frenchTypes";
-import { FrenchTenses, FrenchPronounKeys } from "french-types";
+import { FrenchTenses, FrenchPronounKeys, FrenchBaseVerbConjugation } from "french-types";
 
-export const erConjugation = (infinitive: string, stem: string): BaseFrenchVerb => {
+export const erConjugation = (infinitive: string, stem: string): FrenchBaseVerbConjugation => {
   const lastCharOfStem = stem.charAt(stem.length - 1);
   let variantStem: String | undefined;
 

--- a/apps/db_management/src/models/french/createStandardIrConjugation.ts
+++ b/apps/db_management/src/models/french/createStandardIrConjugation.ts
@@ -1,7 +1,6 @@
-import { BaseFrenchVerb } from "@models/french/frenchTypes"
-import { FrenchTenses, FrenchPronounKeys } from "french-types"
+import { FrenchTenses, FrenchPronounKeys, FrenchBaseVerbConjugation } from "french-types"
 
-export const irConjugation = (infinitive: string, stem: string): BaseFrenchVerb => {
+export const irConjugation = (infinitive: string, stem: string): FrenchBaseVerbConjugation => {
   return {
     infinitive,
     helper_verb: 'avoir',

--- a/apps/db_management/src/models/french/createStandardReConjugation.ts
+++ b/apps/db_management/src/models/french/createStandardReConjugation.ts
@@ -1,7 +1,6 @@
-import { BaseFrenchVerb } from "@models/french/frenchTypes";
-import { FrenchTenses, FrenchPronounKeys, frenchVowels } from "french-types";
+import { FrenchTenses, FrenchPronounKeys, frenchVowels, FrenchBaseVerbConjugation } from "french-types";
 
-const ecrirePattern = (infinitive: string, stem: string): BaseFrenchVerb => {
+const ecrirePattern = (infinitive: string, stem: string): FrenchBaseVerbConjugation => {
   const vStem = `${stem}v`;
 
   return {
@@ -65,7 +64,7 @@ const circomflexMap = {
   u: 'û',
 }
 
-const vowelStem = (infinitive: string, stem: string): BaseFrenchVerb => {
+const vowelStem = (infinitive: string, stem: string): FrenchBaseVerbConjugation => {
   const vowelS = `${stem}s`;
   let participStem = stem;
   let simpleStem = stem;
@@ -150,7 +149,7 @@ const vowelStem = (infinitive: string, stem: string): BaseFrenchVerb => {
   }
 }
 
-export const reConjugation = (infinitive: string, stem: string): BaseFrenchVerb => {
+export const reConjugation = (infinitive: string, stem: string): FrenchBaseVerbConjugation => {
   if (infinitive.slice(-5) === 'crire') {
     return ecrirePattern(infinitive, stem)
   }

--- a/apps/db_management/src/models/french/hydrationFunctions/aitreVerb.ts
+++ b/apps/db_management/src/models/french/hydrationFunctions/aitreVerb.ts
@@ -1,7 +1,6 @@
-import { BaseFrenchVerb } from "@models/french/frenchTypes";
-import { FrenchPronounKeys } from "french-types";
+import { FrenchBaseVerbConjugation, FrenchPronounKeys } from "french-types";
 
-export const modifyAitreVerbs = (verb: BaseFrenchVerb): BaseFrenchVerb => {
+export const modifyAitreVerbs = (verb: FrenchBaseVerbConjugation): FrenchBaseVerbConjugation => {
   const { infinitive } = verb;
   const returnVerb = { ...verb };
 

--- a/apps/db_management/src/models/french/hydrationFunctions/bootVerbs.ts
+++ b/apps/db_management/src/models/french/hydrationFunctions/bootVerbs.ts
@@ -1,5 +1,5 @@
-import { BaseFrenchVerb } from "@models/french/frenchTypes";
 import { TenseType, PronounType } from "@models/french/types/hydrationTypes";
+import { FrenchBaseVerbConjugation } from "french-types";
 
 const doubleConsonant = ['appeler', 'chanceler', 'épeler', 'rappeler',
   'renouveler', 'ruisseler', 'feuilleter', 'hoqueter', 'jeter', 'projeter', 'rejeter'];
@@ -32,7 +32,7 @@ const bootConverter = (sourceConjugation: TenseType, regex: RegExp, substitution
   }, {} as TenseType);
 }
 
-export const modifyBootVerb = (verb: BaseFrenchVerb): BaseFrenchVerb => {
+export const modifyBootVerb = (verb: FrenchBaseVerbConjugation): FrenchBaseVerbConjugation => {
   const { infinitive } = verb;
   const returnVerb = { ...verb };
 

--- a/apps/db_management/src/models/french/hydrationFunctions/enirVerbs.ts
+++ b/apps/db_management/src/models/french/hydrationFunctions/enirVerbs.ts
@@ -1,7 +1,6 @@
-import { BaseFrenchVerb } from "@models/french/frenchTypes";
-import { FrenchPronounKeys } from "french-types";
+import { FrenchBaseVerbConjugation, FrenchPronounKeys } from "french-types";
 
-export const modifyEnirVerbs = (verb: BaseFrenchVerb): BaseFrenchVerb => {
+export const modifyEnirVerbs = (verb: FrenchBaseVerbConjugation): FrenchBaseVerbConjugation => {
   const { infinitive } = verb;
   const returnVerb = { ...verb };
 

--- a/apps/db_management/src/models/french/hydrationFunctions/indreVerb.ts
+++ b/apps/db_management/src/models/french/hydrationFunctions/indreVerb.ts
@@ -1,7 +1,6 @@
-import { BaseFrenchVerb } from "@models/french/frenchTypes"
-import { FrenchTenses, FrenchPronounKeys } from "french-types";
+import { FrenchTenses, FrenchPronounKeys, FrenchBaseVerbConjugation } from "french-types";
 
-export const modifyIndreVerb = (verb: BaseFrenchVerb): BaseFrenchVerb => {
+export const modifyIndreVerb = (verb: FrenchBaseVerbConjugation): FrenchBaseVerbConjugation => {
   const stem = verb.infinitive.slice(0, -3);
   const infinitiveStem = verb.infinitive.slice(0, -2);
   const pluralStem = `${verb.infinitive.slice(0, -4)}gn`

--- a/apps/db_management/src/models/french/hydrationFunctions/irregularFields.ts
+++ b/apps/db_management/src/models/french/hydrationFunctions/irregularFields.ts
@@ -1,10 +1,9 @@
-import { BaseFrenchVerb } from "@models/french/frenchTypes";
 import { IrregularFields } from "@models/french/types/hydrationTypes";
-import { FrenchPronounCode, FrenchTenses } from "french-types";
+import { FrenchBaseVerbConjugation, FrenchPronounCode, FrenchTenses } from "french-types";
 
 type PronounRecord = { [key in FrenchPronounCode]: string | undefined; }
 
-export const irregularFields = (verb: BaseFrenchVerb, irregularFields: IrregularFields): BaseFrenchVerb => {
+export const irregularFields = (verb: FrenchBaseVerbConjugation, irregularFields: IrregularFields): FrenchBaseVerbConjugation => {
 
   Object.entries(irregularFields).forEach(([tense, value]: [string, PronounRecord]) => {
     Object.entries(value).forEach(([pronoun, word]: [string, string | undefined]) => {

--- a/apps/db_management/src/models/french/hydrationFunctions/irregularStems.ts
+++ b/apps/db_management/src/models/french/hydrationFunctions/irregularStems.ts
@@ -1,7 +1,82 @@
-import { BaseFrenchVerb } from "@models/french/frenchTypes";
-import { IrregularStems } from "@models/french/types/hydrationTypes";
+import { FrenchPronounKeys, FrenchTenses } from "french-types";
 
-export const irregularStems = (verb: BaseFrenchVerb, irregularStems: IrregularStems): BaseFrenchVerb => {
-  console.log({ irregularStems });
-  return verb;
+const conditionalImparfait = (stem: string) => ({
+  [FrenchPronounKeys.je]: `${stem}ais`,
+  [FrenchPronounKeys.tu]: `${stem}ais`,
+  [FrenchPronounKeys.il]: `${stem}ait`,
+  [FrenchPronounKeys.nous]: `${stem}ions`,
+  [FrenchPronounKeys.vous]: `${stem}iez`,
+  [FrenchPronounKeys.ils]: `${stem}aient`,
+})
+
+const simpleTense = (stem: string, ending = 'er') => {
+  switch (ending) {
+    case 're':
+      return {
+        [FrenchPronounKeys.je]: `${stem}s`,
+        [FrenchPronounKeys.tu]: `${stem}s`,
+        [FrenchPronounKeys.il]: `${stem}t`,
+        [FrenchPronounKeys.nous]: `${stem}mes`,
+        [FrenchPronounKeys.vous]: `${stem}tes`,
+        [FrenchPronounKeys.ils]: `${stem}rent`,
+      }
+
+    case 'ir':
+      return {
+        [FrenchPronounKeys.je]: `${stem}is`,
+        [FrenchPronounKeys.tu]: `${stem}is`,
+        [FrenchPronounKeys.il]: `${stem}it`,
+        [FrenchPronounKeys.nous]: `${stem}îmes`,
+        [FrenchPronounKeys.vous]: `${stem}îtes`,
+        [FrenchPronounKeys.ils]: `${stem}irent`,
+      }
+
+    default:
+      return {
+        [FrenchPronounKeys.je]: `${stem}ai`,
+        [FrenchPronounKeys.tu]: `${stem}as`,
+        [FrenchPronounKeys.il]: `${stem}a`,
+        [FrenchPronounKeys.nous]: `${stem}âmes`,
+        [FrenchPronounKeys.vous]: `${stem}âtes`,
+        [FrenchPronounKeys.ils]: `${stem}èrent`,
+      }
+  }
+}
+
+const tenseFactory = {
+  [FrenchTenses.présent]: (stem: string) => ({
+    [FrenchPronounKeys.je]: `${stem}e`,
+    [FrenchPronounKeys.tu]: `${stem}es`,
+    [FrenchPronounKeys.il]: `${stem}e`,
+    [FrenchPronounKeys.nous]: `${stem}ons`,
+    [FrenchPronounKeys.vous]: `${stem}ez`,
+    [FrenchPronounKeys.ils]: `${stem}ent`,
+  }),
+  [FrenchTenses.conditional]: conditionalImparfait,
+  [FrenchTenses.imparfait]: conditionalImparfait,
+  [FrenchTenses.futur]: (stem: string) => ({
+    [FrenchPronounKeys.je]: `${stem}ai`,
+    [FrenchPronounKeys.tu]: `${stem}as`,
+    [FrenchPronounKeys.il]: `${stem}a`,
+    [FrenchPronounKeys.nous]: `${stem}ons`,
+    [FrenchPronounKeys.vous]: `${stem}ez`,
+    [FrenchPronounKeys.ils]: `${stem}ont`,
+  }),
+  [FrenchTenses.simple]: simpleTense,
+  [FrenchTenses.subjunctif]: (stem: string) => ({
+    [FrenchPronounKeys.je]: `${stem}e`,
+    [FrenchPronounKeys.tu]: `${stem}es`,
+    [FrenchPronounKeys.il]: `${stem}e`,
+    [FrenchPronounKeys.nous]: `${stem}ions`,
+    [FrenchPronounKeys.vous]: `${stem}iez`,
+    [FrenchPronounKeys.ils]: `${stem}ent`,
+  })
+}
+
+export const irregularStems = (tense: FrenchTenses, stem: string, infinitive: string) => {
+  if (tense === FrenchTenses.simple) {
+    return tenseFactory[tense](stem, infinitive.slice(-2))
+  }
+
+  return tenseFactory[tense](stem);
 }

--- a/apps/db_management/src/models/french/hydrationFunctions/llirVerbs.ts
+++ b/apps/db_management/src/models/french/hydrationFunctions/llirVerbs.ts
@@ -1,7 +1,6 @@
-import { BaseFrenchVerb } from "@models/french/frenchTypes";
-import { FrenchPronounKeys } from "french-types";
+import { FrenchBaseVerbConjugation, FrenchPronounKeys } from "french-types";
 
-export const modifyLlirVerbs = (verb: BaseFrenchVerb): BaseFrenchVerb => {
+export const modifyLlirVerbs = (verb: FrenchBaseVerbConjugation): FrenchBaseVerbConjugation => {
   const { infinitive } = verb;
   const returnVerb = { ...verb };
   const stem = infinitive.slice(0, -2);

--- a/apps/db_management/src/models/french/hydrationFunctions/mirtirVerbs.ts
+++ b/apps/db_management/src/models/french/hydrationFunctions/mirtirVerbs.ts
@@ -1,7 +1,6 @@
-import { BaseFrenchVerb } from "@models/french/frenchTypes";
-import { FrenchPronounKeys } from "french-types";
+import { FrenchBaseVerbConjugation, FrenchPronounKeys } from "french-types";
 
-export const modifyMirtirVerbs = (verb: BaseFrenchVerb): BaseFrenchVerb => {
+export const modifyMirtirVerbs = (verb: FrenchBaseVerbConjugation): FrenchBaseVerbConjugation => {
   const { infinitive } = verb;
   const returnVerb = { ...verb };
 

--- a/apps/db_management/src/models/french/hydrationFunctions/rendreVerb.ts
+++ b/apps/db_management/src/models/french/hydrationFunctions/rendreVerb.ts
@@ -1,7 +1,6 @@
-import { BaseFrenchVerb } from "@models/french/frenchTypes";
-import { FrenchPronounKeys } from "french-types";
+import { FrenchBaseVerbConjugation, FrenchPronounKeys } from "french-types";
 
-export const modifyRendreVerb = (verb: BaseFrenchVerb): BaseFrenchVerb => {
+export const modifyRendreVerb = (verb: FrenchBaseVerbConjugation): FrenchBaseVerbConjugation => {
   const { infinitive } = verb;
   const newVerb = { ...verb };
 

--- a/apps/db_management/src/models/french/hydrationFunctions/ttreVerb.ts
+++ b/apps/db_management/src/models/french/hydrationFunctions/ttreVerb.ts
@@ -1,7 +1,6 @@
-import { BaseFrenchVerb } from "@models/french/frenchTypes";
-import { FrenchPronounKeys } from "french-types";
+import { FrenchBaseVerbConjugation, FrenchPronounKeys } from "french-types";
 
-export const modifyTtreVerb = (verb: BaseFrenchVerb): BaseFrenchVerb => {
+export const modifyTtreVerb = (verb: FrenchBaseVerbConjugation): FrenchBaseVerbConjugation => {
   const { infinitive } = verb;
 
   const newVerb = { ...verb };

--- a/apps/db_management/src/models/french/processFrRecord.spec.ts
+++ b/apps/db_management/src/models/french/processFrRecord.spec.ts
@@ -1,0 +1,38 @@
+import { boireReturnObject } from '@models/french/spec_constants/irregurlarVerbs';
+import { processFrRecord } from './processFrRecord';
+import { LanguageMap, LanguageVerbCandidate } from 'global-types';
+
+describe('processFrRecord', () => {
+  let testObject: LanguageVerbCandidate;
+  it('returns correctly for boire.', () => {
+    testObject = {
+      infinitive: 'boire',
+      language: LanguageMap.fr,
+      irregular: {
+        participe: 'bu',
+        present_participe: "buvant",
+        présent: {
+          nous: 'buvons',
+          vous: 'buvez',
+          ils: 'boivent',
+        },
+        simple: {
+          nous: 'bûmes',
+          vous: 'bûtes'
+        }
+      },
+      stems: {
+        imparfait: 'buv',
+        simple: 'bui',
+        subjunctif: 'boiv'
+      },
+      translations: {
+        en: 'drink'
+      }
+    };
+
+    const result = processFrRecord(testObject);
+
+    expect(result).toStrictEqual({ ...boireReturnObject, language: LanguageMap.fr });
+  });
+})

--- a/apps/db_management/src/models/french/spec_constants/irregurlarVerbs.ts
+++ b/apps/db_management/src/models/french/spec_constants/irregurlarVerbs.ts
@@ -342,3 +342,58 @@ export const écrireReturnObject = {
     1300: 'écrivent'
   }
 };
+
+export const boireReturnObject = {
+  infinitive: 'boire',
+  conditional: {
+    1033: 'boirais',
+    1041: 'boirions',
+    1074: 'boiriez',
+    1098: 'boirais',
+    1292: 'boirait',
+    1300: 'boiraient'
+  },
+  futur: {
+    1033: 'boirai',
+    1041: 'boirons',
+    1074: 'boirez',
+    1098: 'boiras',
+    1292: 'boira',
+    1300: 'boiront'
+  },
+  helper_verb: 'avoir',
+  imparfait: {
+    1033: 'buvais',
+    1041: 'buvions',
+    1074: 'buviez',
+    1098: 'buvais',
+    1292: 'buvait',
+    1300: 'buvaient'
+  },
+  participe: 'bu',
+  present_participe: 'buvant',
+  présent: {
+    1033: 'bois',
+    1041: 'buvons',
+    1074: 'buvez',
+    1098: 'bois',
+    1292: 'boit',
+    1300: 'boivent'
+  },
+  simple: {
+    1033: 'buis',
+    1041: 'bûmes',
+    1074: 'bûtes',
+    1098: 'buis',
+    1292: 'buit',
+    1300: 'buirent'
+  },
+  subjunctif: {
+    1033: 'boive',
+    1041: 'boivions',
+    1074: 'boiviez',
+    1098: 'boives',
+    1292: 'boive',
+    1300: 'boivent'
+  }
+};

--- a/shared-types/french-types/src/frenchTypes.spec.ts
+++ b/shared-types/french-types/src/frenchTypes.spec.ts
@@ -23,4 +23,49 @@ describe('frenchTypes', () => {
     const frenchVerb = isFrenchVerb(testRecord);
     expect(frenchVerb).toBeFalsy();
   });
+
+  it('passes an object with correct keys', () => {
+    const testRecord = {
+      language: LanguageMap.fr,
+      translations: { [LanguageMap.en]: ['fade out', 'dim (lights)'] },
+      infinitive: 'parler',
+      definition: 'speak'
+    };
+
+    const frenchVerb = isFrenchVerb(testRecord);
+    expect(frenchVerb).toBeTruthy();
+  });
+
+  it('passes a complex object with correct keys', () => {
+    const testRecord = {
+      language: LanguageMap.fr,
+      translations: { [LanguageMap.en]: ['serve as', 'act as'] },
+      infinitive: 'servir',
+      definition: 'serve',
+      irregular: {
+        présent: {
+          je: 'sers',
+          tu: 'sers',
+          il: 'sert',
+        }
+      },
+      reflexive: true
+    };
+
+    const frenchVerb = isFrenchVerb(testRecord);
+    expect(frenchVerb).toBeTruthy();
+  });
+
+  it('passes an complex object with correct keys', () => {
+    const testRecord = {
+      language: LanguageMap.fr,
+      translations: { [LanguageMap.en]: ['serve as', 'act as'] },
+      infinitive: 'pluvoir',
+      definition: 'rain',
+      impersonal: true
+    };
+
+    const frenchVerb = isFrenchVerb(testRecord);
+    expect(frenchVerb).toBeTruthy();
+  });
 });

--- a/shared-types/french-types/src/frenchTypes.ts
+++ b/shared-types/french-types/src/frenchTypes.ts
@@ -3,13 +3,14 @@ import { FrenchPronounCode } from "src/frenchConstants";
 
 const ALL_FRENCH_VALID_KEYS = [
   'auxiliary',
-  'boot',
   'definition',
   'helper_verb', // être/avoir
+  'irregular',
   'impersonal',
   'infinitive',
   'language',
   'participe',
+  'pattern',
   'present_participle',
   'préposition',
   'reflexive',
@@ -18,52 +19,69 @@ const ALL_FRENCH_VALID_KEYS = [
   'variations',
 ];
 
-const ALL_FRENCH_STEMS = [
-  'futur',
-  'present-2p',
-  'subj-1',
-  'subj-1pl',
-  'imperitive',
-  'simple-past'
+const ALL_FRENCH_PATTERNS = [
+  'aitre',
+  'boot',
+  'indre',
+  'rendre',
+  'ttre',
 ] as const;
-export type FrenchStem = typeof ALL_FRENCH_STEMS[number];
+export type FrenchPattern = typeof ALL_FRENCH_PATTERNS[number];
 
 export enum FrenchTenses {
   conditional = 'conditional',
   futur = 'futur', // futre
   imparfait = 'imparfait', // past
-  imperitif = 'imperitif',
+  // imperitif = 'imperitif',
   présent = 'présent', // present
   simple = 'simple', // past - story, history
   subjunctif = 'subjunctif',
 }
 
+export const allFrenchTenses = Object.keys(FrenchTenses);
+
+export type FrenchBaseVerbConjugation = {
+  [key in FrenchTenses]: { [key in FrenchPronounCode]: string };
+} & {
+  definition?: string;
+  helper_verb: 'avoir' | 'être';
+  impersonal?: boolean;
+  infinitive: string;
+  participe: string;
+  present_participe: string;
+  préposition?: string;
+  reflexive?: boolean;
+}
+
 export type FrenchVerbVariation = {
   [key in FrenchTenses]?: { [key in FrenchPronounCode]: string };
 } & {
-  auxiliary?: boolean;
   definition?: string;
-  helper_verb: string;
-  infinitive: string;
-  impersonal?: boolean;
-  participe: string;
   préposition?: string;
-  present_participe: string;
+  reflexive: boolean;
   translations: TranslationSet;
 };
 
 export type FrenchIrregularSet = Record<FrenchPronounCode, string>;
 export type FrenchIrregularObject = {
-  // [key in FrenchIrregularKeys]?: FrenchIrregularSet;
-  [FrenchTenses.imparfait]: Record<FrenchPronounCode, string>;
+  [key in FrenchTenses]?: Record<FrenchPronounCode, string>;
+} | {
+  participe: string;
+  present_participle: string;
 };
 
 export interface FrenchVerb extends LanguageVerbBase {
+  auxiliary?: boolean;
+  definition?: string;
+  helper_verb: string;
   impersonal: boolean;
   infinitive: string;
   irregular?: FrenchIrregularObject;
-  stems?: { [key in FrenchStem]?: string };
-  strong?: boolean;
+  pattern?: FrenchPattern;
+  participe: string;
+  present_participe: string;
+  reflexive: boolean;
+  stems: Record<FrenchTenses, string>
   translations: TranslationSet;
   variations?: Array<Partial<FrenchVerb> | { definition: string }>;
   weakEndings?: boolean;
@@ -75,6 +93,16 @@ export const isFrenchVerb = (x: object): x is FrenchVerb => {
   if ('language' in x && x.language !== 'fr') {
     return false;
   }
+
+  const xKeys = Object.keys(x);
+  xKeys.forEach((key: string) => {
+    if (!ALL_FRENCH_VALID_KEYS.includes(key)) {
+      console.log(`bad key = ${key}`);
+      isValid = false;
+    }
+
+    // TODO: validate tenses and persons
+  });
 
   return isValid;
 }

--- a/shared-types/german-types/src/germanTypes.ts
+++ b/shared-types/german-types/src/germanTypes.ts
@@ -256,14 +256,6 @@ export interface GermanSeparableVerb extends LanguageVerbBase {
   particle: SeperableGermanParticles;
 }
 
-const validSeperableKeys = [
-  'base',
-  'hilfsverb',
-  'language',
-  'particle',
-  'translations',
-];
-
 export const isGermanSeparableVerb = (x: object): x is GermanSeparableVerb => {
   let returnValue = true;
 


### PR DESCRIPTION
Created conjugation for boire, using `processFrRecord` to take a configuration and encode accurately all the irregularities.

This change also includes redefining several types in the French model, hopefully to be more clear.