### PR TITLE
feat: add avoir handling

### DIFF
--- a/apps/db_management/src/models/french/processFrRecord.spec.ts
+++ b/apps/db_management/src/models/french/processFrRecord.spec.ts
@@ -1,4 +1,4 @@
-import { boireReturnObject } from '@models/french/spec_constants/irregurlarVerbs';
+import { avoirReturnObject, boireReturnObject } from '@models/french/spec_constants/irregurlarVerbs';
 import { processFrRecord } from './processFrRecord';
 import { LanguageMap, LanguageVerbCandidate } from 'global-types';
 
@@ -34,5 +34,50 @@ describe('processFrRecord', () => {
     const result = processFrRecord(testObject);
 
     expect(result).toStrictEqual({ ...boireReturnObject, language: LanguageMap.fr });
+  });
+
+  it('returns correctly for avoir.', () => {
+    testObject = {
+      infinitive: 'avoir',
+      language: LanguageMap.fr,
+      irregular: {
+        participe: 'eu',
+        present_participe: "ayant",
+        présent: {
+          je: 'ai',
+          tu: 'as',
+          il: 'a',
+          nous: 'avons',
+          vous: 'avez',
+          ils: 'ont',
+        },
+        subjunctif: {
+          il: 'ait',
+          nous: 'ayons',
+          vous: 'ayez'
+        },
+        simple: {
+          je: 'eus',
+          tu: 'eus',
+          il: 'eut',
+          nous: 'eûmes',
+          vous: 'eûtes',
+          ils: 'eurent',
+        }
+      },
+      stems: {
+        imparfait: 'av',
+        futur: 'aur',
+        conditional: 'aur',
+        subjunctif: 'ai'
+      },
+      translations: {
+        en: 'have'
+      }
+    };
+
+    const result = processFrRecord(testObject);
+
+    expect(result).toStrictEqual({ ...avoirReturnObject, language: LanguageMap.fr });
   });
 })

--- a/apps/db_management/src/models/french/spec_constants/irregurlarVerbs.ts
+++ b/apps/db_management/src/models/french/spec_constants/irregurlarVerbs.ts
@@ -397,3 +397,58 @@ export const boireReturnObject = {
     1300: 'boivent'
   }
 };
+
+export const avoirReturnObject = {
+  infinitive: 'avoir',
+  conditional: {
+    1033: 'aurais',
+    1041: 'aurions',
+    1074: 'auriez',
+    1098: 'aurais',
+    1292: 'aurait',
+    1300: 'auraient'
+  },
+  futur: {
+    1033: 'aurai',
+    1041: 'aurons',
+    1074: 'aurez',
+    1098: 'auras',
+    1292: 'aura',
+    1300: 'auront'
+  },
+  helper_verb: 'avoir',
+  imparfait: {
+    1033: 'avais',
+    1041: 'avions',
+    1074: 'aviez',
+    1098: 'avais',
+    1292: 'avait',
+    1300: 'avaient'
+  },
+  participe: 'eu',
+  present_participe: 'ayant',
+  présent: {
+    1033: 'ai',
+    1041: 'avons',
+    1074: 'avez',
+    1098: 'as',
+    1292: 'a',
+    1300: 'ont'
+  },
+  simple: {
+    1033: 'eus',
+    1041: 'eûmes',
+    1074: 'eûtes',
+    1098: 'eus',
+    1292: 'eut',
+    1300: 'eurent'
+  },
+  subjunctif: {
+    1033: 'aie',
+    1041: 'ayons',
+    1074: 'ayez',
+    1098: 'aies',
+    1292: 'ait',
+    1300: 'aient'
+  }
+};


### PR DESCRIPTION
Added avoir as a test for `processFrRecord` and didn't need to add additional handlers.